### PR TITLE
chore: remove ngcc postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "workspace-schematic": "nx workspace-schematic",
     "dep-graph": "nx dep-graph",
     "help": "nx help",
-    "_postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points",
-    "state:publish": "nx test state && nx build state --prod && cd ./dist/libs/state && npm publish",
-    "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
+    "state:publish": "nx test state && nx build state --prod && cd ./dist/libs/state && npm publish"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
It's doesn't seem to be needed anymore. This has changed a lot in the Angular 9.x releases.

If it's needed again, it should be something like

```
"postinstall": "ngcc && ngcc --properties main"
```

The last part is for producing UMD bundles for Jest.