### PR TITLE
refactor(template): remove unnecessary metadata from template module

### DIFF
--- a/libs/template/src/lib/template.module.ts
+++ b/libs/template/src/lib/template.module.ts
@@ -1,10 +1,9 @@
 import { NgModule } from '@angular/core';
+
 import { LetModule } from './let';
 import { PushModule } from './push';
 
-const MODULES = [LetModule, PushModule];
 @NgModule({
-  imports: MODULES,
-  exports: MODULES
+  exports: [LetModule, PushModule]
 })
 export class TemplateModule {}


### PR DESCRIPTION
There's no need to add Angular modules to `imports` when we don't have `declarations`.

After this refactor, I don't see the need for the `MODULES` constant.