### PR TITLE
feat: add back tslib dependency

### DIFF
--- a/libs/state/package.json
+++ b/libs/state/package.json
@@ -25,6 +25,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">8.0.0",
-    "rxjs": "^6.5.5"
+    "rxjs": "^6.5.5",
+    "tslib": "^1.10.0"
   }
 }

--- a/libs/template/package.json
+++ b/libs/template/package.json
@@ -25,6 +25,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">8.0.0",
-    "rxjs": "^6.5.5"
+    "rxjs": "^6.5.5",
+    "tslib": "^1.10.0"
   }
 }


### PR DESCRIPTION
This is technically a breaking change, but it's default for Angular package libraries, so it shouldn't be a big deal.

Note that we currently use `tslib` v1.11.x in this workspace, but Angular CLI 9.0.x apps come with v1.10.x out-of-the-box.