### PR TITLE
chore: downgrade to minimum compatible package dependencies

### DIFF
--- a/libs/state/package.json
+++ b/libs/state/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">8.0.0",
-    "rxjs": "^6.5.5",
+    "rxjs": "^6.5.4",
     "tslib": "^1.10.0"
   }
 }

--- a/libs/template/package.json
+++ b/libs/template/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">8.0.0",
-    "rxjs": "^6.5.5",
+    "rxjs": "^6.5.4",
     "tslib": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "@nrwl/node": "^9.2.2",
     "@rx-angular/state": "^1.0.0-rc.0",
     "core-js": "^3.6.5",
-    "rxjs": "~6.5.5",
-    "tslib": "^1.11.1",
-    "zone.js": "^0.10.3"
+    "rxjs": "~6.5.4",
+    "tslib": "~1.10.0",
+    "zone.js": "~0.10.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.901.1",
@@ -84,8 +84,8 @@
     "ng-packagr": "^9.0.0",
     "prettier": "1.19.1",
     "ts-jest": "25.2.1",
-    "ts-node": "~7.0.0",
-    "tslint": "~6.0.0",
-    "typescript": "~3.8.3"
+    "ts-node": "~8.3.0",
+    "tslint": "~5.18.0",
+    "typescript": "~3.7.5"
   }
 }


### PR DESCRIPTION
Downgrade to the minimum versions supported by an Angular CLI 9.0.x app.

NOTE: Consider dropping Angular 8.x support since we don't test that version.