### PR TITLE
fix(template) fixed a bug in the promise-duration-selector 

### DIFF
--- a/libs/template/src/lib/core/render-aware/promise-duration-selector.ts
+++ b/libs/template/src/lib/core/render-aware/promise-duration-selector.ts
@@ -8,9 +8,10 @@ let resolvedPromise: Promise<void> | null = null;
 
 function getResolvedPromise(): Promise<void> {
   resolvedPromise =
-    resolvedPromise || apiZonePatched('Promise')
+    resolvedPromise ||
+    (apiZonePatched('Promise')
       ? (getGlobalThis().__zone_symbol__Promise.resolve() as Promise<void>)
-      : Promise.resolve();
+      : Promise.resolve());
   return resolvedPromise;
 }
 


### PR DESCRIPTION
…which caused crashes when zone was not included.

There were missing brackets.