### PR TITLE
fix(let) fix strategy input binding

### DIFF
--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -103,7 +103,7 @@ export class LetDirective<U> implements OnDestroy {
     this.renderAware.nextPotentialObservable(potentialObservable);
   }
 
-  @Input()
+  @Input('rxLetStrategy')
   set strategy(config: string | Observable<string> | undefined) {
     if (config) {
       this.renderAware.nextStrategy(config);


### PR DESCRIPTION
otherwise it is not possible to set the strategy via: `<div *rxLet="o$; strategy: 'strat'; let o"></div>`