### PR TITLE
fix(render-aware) fixed broken strategy selection

### DIFF
--- a/libs/template/src/lib/core/render-aware/render-aware_creator.ts
+++ b/libs/template/src/lib/core/render-aware/render-aware_creator.ts
@@ -56,7 +56,7 @@ export function createRenderAware<U>(cfg: {
     switchMap(stringOrObservable =>
       typeof stringOrObservable === 'string'
         ? of(stringOrObservable)
-        : stringOrObservable.pipe(mergeAll())
+        : stringOrObservable
     ),
     nameToStrategy(cfg.strategies),
     tap(s => (strategy = s))


### PR DESCRIPTION
if strategy is provided as observable, mergeAll() operator just causes the string e.g. "local" to get emitted as "l", "o", "c", "a", "l". 