### PR TITLE
fix: detect zone.js by using runOutsideAngular()

### DIFF
--- a/libs/template/spec/core/utils/zone-check.spec.ts
+++ b/libs/template/spec/core/utils/zone-check.spec.ts
@@ -1,15 +1,11 @@
 import { isNgZone } from '../../../src/lib/core/utils';
-import {
-  manualInstanceNgZone,
-  manualInstanceNoopNgZone
-} from '../../fixtures/fixtures';
 
 describe('envZonePatched', () => {
   it('should return true if `zone.js` did patch the global API', () => {
-    expect(isNgZone(manualInstanceNgZone)).toBe(true);
+    expect(isNgZone({ runOutsideAngular (fn) { fn.apply(null) } })).toBe(true);
   });
 
   it('should return false if `zone.js` did not patch the global API', () => {
-    expect(isNgZone(manualInstanceNoopNgZone)).toBe(false);
+    expect(isNgZone({ runOutsideAngular (fn) { fn() } })).toBe(false);
   });
 });

--- a/libs/template/spec/fixtures/fixtures.ts
+++ b/libs/template/spec/fixtures/fixtures.ts
@@ -1,26 +1,5 @@
 import createSpy = jasmine.createSpy;
 import { ChangeDetectorRef } from '@angular/core';
-import { MockNgZone } from './mock-ng-zone';
-import { MockNoopNgZone } from './mock-noop-ng-zone';
-
-/**
- * this is not exposed as NgZone should never be exposed to get miss matched with the real one
- */
-class NgZone extends MockNgZone {}
-
-/**
- * this is not exposed as NgZone should never be exposed to get miss matched with the real one
- */
-class NoopNgZone extends MockNoopNgZone {}
-
-export const manualInstanceNgZone = new NgZone({
-  enableLongStackTrace: false,
-  shouldCoalesceEventChangeDetection: false
-});
-export const manualInstanceNoopNgZone = new NoopNgZone({
-  enableLongStackTrace: false,
-  shouldCoalesceEventChangeDetection: false
-});
 
 export class MockChangeDetectorRef {
   markForCheck = createSpy('markForCheck');

--- a/libs/template/src/lib/core/utils/zone-checks.ts
+++ b/libs/template/src/lib/core/utils/zone-checks.ts
@@ -38,10 +38,10 @@ export function apiZonePatched(name: string): boolean {
  *
  * @description
  *
- * This function takes any instance of a class and checks
- * if the constructor name is equal to `NgZone`.
- * This means the Angular application that instantiated this service assumes it runs in a ZoneLess environment,
- * and therefor it's change detection will not be triggered by zone related logic.
+ * This function takes an instance of a class which implements the NgZone interface and checks if
+ * its `runOutsideAngular()` function calls `apply()` on the function passed as parameter. This
+ * means the Angular application that instantiated this service assumes it runs in a ZoneLess
+ * environment, and therefore it's change detection will not be triggered by zone related logic.
  *
  * However, keep in mind this does not mean `zone.js` is not present.
  * The environment could still run in ZoneFull mode even if Angular turned it off.
@@ -53,7 +53,14 @@ export function apiZonePatched(name: string): boolean {
  *
  */
 export function isNgZone(instance: any): boolean {
-  return instance?.constructor?.name === 'NgZone';
+  let calledApply = false;
+
+  function fn() {}
+  fn.apply = () => (calledApply = true);
+
+  instance.runOutsideAngular(fn);
+
+  return calledApply;
 }
 
 /**
@@ -71,5 +78,5 @@ export function isNgZone(instance: any): boolean {
  *
  */
 export function isNoopNgZone(instance: any): boolean {
-  return instance?.constructor?.name === 'NoopNgZone';
+  return !isNgZone(instance);
 }


### PR DESCRIPTION
This pull request aims to match the changes introduced here: ngrx/platform#2547.

It changes the way zone.js gets detected.