### PR TITLE
fix typo in function name

### DIFF
--- a/libs/state/perf/index.ts
+++ b/libs/state/perf/index.ts
@@ -1,4 +1,4 @@
-import { runBenchmarkSuit } from './utils';
+import { runBenchmarkSuite } from './utils';
 import { oneOfSuite } from './core/transformation-helpers/one-of.suite';
 
-runBenchmarkSuit(oneOfSuite);
+runBenchmarkSuite(oneOfSuite);

--- a/libs/state/perf/utils/index.ts
+++ b/libs/state/perf/utils/index.ts
@@ -14,7 +14,7 @@ export interface BenchmarkSuite {
   options?: Benchmark.Options;
 }
 
-export function runBenchmarkSuit(benchmarkSuite: BenchmarkSuite) {
+export function runBenchmarkSuite(benchmarkSuite: BenchmarkSuite) {
   const suite = new Benchmark.Suite();
   const listeners: BenchmarkListener = {
     cycle: function(event: Event) {


### PR DESCRIPTION
This pull request just adds three "e"s to fix a typo in function name.