### PR TITLE
fix(template): render aware strategy handling stable on resubscribe

### DIFF
--- a/libs/template/src/lib/core/render-aware/render-aware_creator.ts
+++ b/libs/template/src/lib/core/render-aware/render-aware_creator.ts
@@ -84,14 +84,10 @@ export function createRenderAware<U>(cfg: {
     // forward only observable values
     filter(o$ => isObservable(o$)),
     map(o$ =>
-      updateStrategyEffect$.pipe(
-        switchMap(() =>
-          o$.pipe(
-            distinctUntilChanged(),
-            tap(cfg.updateObserver),
-            strategy.behavior
-          )
-        )
+      o$.pipe(
+        distinctUntilChanged(),
+        tap(cfg.updateObserver),
+        strategy.behavior
       )
     ),
     switchAll(),


### PR DESCRIPTION
Loosing state on resubscribe fixed. Removed switchMap as we now use connect to set the strategy.