### PR TITLE
Log errors in accumulator

### DIFF
--- a/libs/state/spec/core/accumulation-observable.spec.ts
+++ b/libs/state/spec/core/accumulation-observable.spec.ts
@@ -1,8 +1,8 @@
 import { jestMatcher } from '@test-helpers';
-import { interval, of } from 'rxjs';
+import { interval, of, throwError } from 'rxjs';
 import { map, pluck, switchMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { createAccumulationObservable, select } from '../../src/lib/core';
+import { createAccumulationObservable, select, stateful } from '../../src/lib/core';
 import { initialPrimitiveState, PrimitiveState } from '../fixtures';
 
 
@@ -62,6 +62,15 @@ describe('createAccumulationObservable', () => {
       const valuesInOrder = ['', { num: 777 }];
       slice$.subscribe(next => expect(next).toBe(valuesInOrder[++i]));
       state.nextSlice({ num: 777 });
+    });
+
+    it('should log error if getting error', () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation();
+      const state = setupAccumulationObservable<PrimitiveState>({});
+      state.nextSliceObservable(throwError('test') as any);
+      state.subscribe();
+
+      expect(spy).toBeCalled();
     });
   });
 

--- a/libs/state/src/lib/core/accumulation-observable.ts
+++ b/libs/state/src/lib/core/accumulation-observable.ts
@@ -6,7 +6,8 @@ import {
   queueScheduler,
   Subject,
   Subscribable,
-  Subscription
+  Subscription,
+  EMPTY
 } from 'rxjs';
 import {
   distinctUntilChanged,
@@ -16,7 +17,8 @@ import {
   publishReplay,
   scan,
   tap,
-  withLatestFrom
+  withLatestFrom,
+  catchError
 } from 'rxjs/operators';
 
 export type AccumulationFn = <T>(st: T, sl: Partial<T>) => T;
@@ -56,7 +58,7 @@ export function createAccumulationObservable<T extends object>(
       newState => (compositionObservable.state = newState),
       error => console.error(error)
     ),
-    catchError(e => EMPTY)
+    catchError(e => EMPTY),
     publish()
   );
   const state$: Observable<T> = signal$.pipe(publishReplay(1));

--- a/libs/state/src/lib/core/accumulation-observable.ts
+++ b/libs/state/src/lib/core/accumulation-observable.ts
@@ -56,6 +56,7 @@ export function createAccumulationObservable<T extends object>(
       newState => (compositionObservable.state = newState),
       error => console.error(error)
     ),
+    catchError(e => EMPTY)
     publish()
   );
   const state$: Observable<T> = signal$.pipe(publishReplay(1));

--- a/libs/state/src/lib/core/accumulation-observable.ts
+++ b/libs/state/src/lib/core/accumulation-observable.ts
@@ -94,6 +94,11 @@ export function createAccumulationObservable<T extends object>(
     sub.add(
       (compositionObservable.state$ as ConnectableObservable<T>).connect()
     );
+    sub.add(() => {
+      accumulatorObservable.complete();
+      stateObservables.complete();
+      stateSlices.complete();
+    });
     return sub;
   }
 }

--- a/libs/state/src/lib/core/accumulation-observable.ts
+++ b/libs/state/src/lib/core/accumulation-observable.ts
@@ -52,7 +52,10 @@ export function createAccumulationObservable<T extends object>(
       (state, [slice, stateAccumulator]) => stateAccumulator(state, slice),
       {} as T
     ),
-    tap(newState => (compositionObservable.state = newState)),
+    tap(
+      newState => (compositionObservable.state = newState),
+      error => console.error(error)
+    ),
     publish()
   );
   const state$: Observable<T> = signal$.pipe(publishReplay(1));
@@ -91,11 +94,6 @@ export function createAccumulationObservable<T extends object>(
     sub.add(
       (compositionObservable.state$ as ConnectableObservable<T>).connect()
     );
-    sub.add(() => {
-      accumulatorObservable.complete();
-      stateObservables.complete();
-      stateSlices.complete();
-    });
     return sub;
   }
 }

--- a/libs/state/src/lib/core/accumulation-observable.ts
+++ b/libs/state/src/lib/core/accumulation-observable.ts
@@ -58,6 +58,7 @@ export function createAccumulationObservable<T extends object>(
       newState => (compositionObservable.state = newState),
       error => console.error(error)
     ),
+    // @Notice We catch the error here as it get lost in between `publish` and `publishReplay`. We return empty to
     catchError(e => EMPTY),
     publish()
   );


### PR DESCRIPTION
### Issue

When an error happens inside the connect method it is not appearing in the console. Only can be reproduced if we use select() to get data from the source. If we use $ everything is fine.

### Guess

Sometime after 1.0 we introduced publish() + publishReplay(1) in state accumulator.
```
 const signal$ = merge(
    stateObservables.pipe(
      distinctUntilChanged(),
      mergeAll(),
      observeOn(queueScheduler)
    ),
    stateSlices.pipe(observeOn(queueScheduler))
  ).pipe(
    scan(stateAccumulator, {} as T),
    tap(newState => (compositionObservable.state = newState)),
    publish()
  );
  const state$ = signal$.pipe(publishReplay(1));
```
And after that errors disappeared. If we keep `state$ = signal$` without publishReplay errors appear as they should do.

### Fix

Not the perfect solution but gets the job done. We can adjust tap a tiny bit.
```
tap(
    newState => (compositionObservable.state = newState),
    error => console.error(error)
),
```

