### PR TITLE
Template bindings for rxLet

### DIFF
--- a/libs/template/src/lib/core/utils/template-manager.ts
+++ b/libs/template/src/lib/core/utils/template-manager.ts
@@ -2,14 +2,17 @@ import { EmbeddedViewRef, TemplateRef, ViewContainerRef } from '@angular/core';
 
 type RxTemplateName = 'rxNext' | 'rxComplete' | 'rxError' | 'rxSuspense';
 
-export class TemplateManager<T extends object> {
+export class TemplateManager<T> {
   private templateCache = new Map<RxTemplateName, TemplateRef<T>>();
   private viewCache = new Map<RxTemplateName, EmbeddedViewRef<T>>();
+  private readonly viewContext: T;
 
   constructor(
-    private viewContext: T,
-    private viewContainerRef: ViewContainerRef
-  ) {}
+    private viewContainerRef: ViewContainerRef,
+    initialViewContext: T
+  ) {
+    this.viewContext = { ...initialViewContext };
+  }
 
   updateViewContext(viewContextSlice: Partial<T>): void {
     Object.entries(viewContextSlice).forEach(([key, value]) => {

--- a/libs/template/src/lib/core/utils/template-manager.ts
+++ b/libs/template/src/lib/core/utils/template-manager.ts
@@ -1,0 +1,59 @@
+import { EmbeddedViewRef, TemplateRef, ViewContainerRef } from '@angular/core';
+
+type RxTemplateName = 'rxNext' | 'rxComplete' | 'rxError' | 'rxSuspense';
+
+export class TemplateManager<T extends object> {
+  private templateCache = new Map<RxTemplateName, TemplateRef<T>>();
+  private viewCache = new Map<RxTemplateName, EmbeddedViewRef<T>>();
+
+  constructor(
+    private viewContext: T,
+    private viewContainerRef: ViewContainerRef
+  ) {}
+
+  updateViewContext(viewContextSlice: Partial<T>): void {
+    Object.entries(viewContextSlice).forEach(([key, value]) => {
+      this.viewContext[key] = value;
+    });
+  }
+
+  addTemplateRef(name: RxTemplateName, templateRef: TemplateRef<T>): void {
+    assertTemplate(name, templateRef);
+    this.templateCache.set(name, templateRef);
+  }
+
+  insertEmbeddedView(name: RxTemplateName) {
+    if (this.templateCache.has(name)) {
+      this.viewContainerRef.detach();
+      if (this.viewCache.has(name)) {
+        this.viewContainerRef.insert(this.viewCache.get(name));
+      } else {
+        const newView = this.viewContainerRef.createEmbeddedView(
+          this.templateCache.get(name),
+          this.viewContext
+        );
+        this.viewCache.set(name, newView);
+      }
+    }
+  }
+
+  destroy() {
+    this.viewCache.forEach(embeddedView => embeddedView?.destroy());
+    this.viewContainerRef.clear();
+  }
+}
+
+function assertTemplate<T>(
+  property: string,
+  templateRef: TemplateRef<T> | null
+): templateRef is TemplateRef<T> {
+  const isTemplateRefOrNull = !!(
+    !templateRef || templateRef.createEmbeddedView
+  );
+  if (!isTemplateRefOrNull) {
+    throw new Error(
+      `${property} must be a TemplateRef, but received something else.`
+    );
+  }
+  return isTemplateRefOrNull;
+}

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -163,12 +163,16 @@ export class LetDirective<U> implements OnInit, OnDestroy {
       });
     },
     error: (error: Error) => {
+      // fallback to rxNext when there's no template for rxError
+      this.templateManager.insertEmbeddedView('rxNext');
       this.templateManager.insertEmbeddedView('rxError');
       this.templateManager.updateViewContext({
         $error: true
       });
     },
     complete: () => {
+      // fallback to rxNext when there's no template for rxComplete
+      this.templateManager.insertEmbeddedView('rxNext');
       this.templateManager.insertEmbeddedView('rxComplete');
       this.templateManager.updateViewContext({
         $complete: true

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -24,13 +24,13 @@ import { TemplateManager } from '../core/utils/template-manager';
 
 export interface LetViewContext<T> {
   // to enable `let` syntax we have to use $implicit (var; let v = var)
-  $implicit?: T;
+  $implicit: T;
   // to enable `as` syntax we have to assign the directives selector (var as v)
-  rxLet?: T;
+  rxLet: T;
   // set context var complete to true (var$; let e = $error)
-  $error?: boolean;
+  $error: boolean;
   // set context var complete to true (var$; let c = $complete)
-  $complete?: boolean;
+  $complete: boolean;
 }
 
 /**
@@ -144,12 +144,6 @@ export class LetDirective<U> implements OnInit, OnDestroy {
   private readonly templateManager: TemplateManager<
     LetViewContext<U | undefined | null>
   >;
-  private readonly viewContext: LetViewContext<U | undefined | null> = {
-    $implicit: undefined,
-    rxLet: undefined,
-    $error: false,
-    $complete: false
-  };
   private readonly resetObserver: NextObserver<void> = {
     next: () => {
       this.templateManager.updateViewContext({
@@ -195,10 +189,12 @@ export class LetDirective<U> implements OnInit, OnDestroy {
     private readonly viewContainerRef: ViewContainerRef
   ) {
     this.strategies = getStrategies({ cdRef });
-    this.templateManager = new TemplateManager(
-      this.viewContext,
-      this.viewContainerRef
-    );
+    this.templateManager = new TemplateManager(this.viewContainerRef, {
+      $implicit: undefined,
+      rxLet: undefined,
+      $error: false,
+      $complete: false
+    });
 
     this.renderAware = createRenderAware({
       strategies: this.strategies,


### PR DESCRIPTION
## Description

This PR adds `ng-template` bindings to be used with `LetDirective`. With this, we can create and bind templates for different state of an observable:
- **next** - when values are emitted
- **complete** - on observable completion 
- **error** - on observable error
- 🔥 **suspense** 🔥 - render something before the first value is emitted from an observable

## What's next?

Work is still in progress. The initial implementation is there but there's still some things to do before we could say it's 100% completed:
- [x] Implement the feature itself
- [ ] Ensure that all previous test are passing and the previous functionality still works
- [ ] Add tests
- [ ] Update docs for LetDirective (jsdocs and Markdown)
- [ ] Add comments explaining low-level implementation details
- [ ] Add new page with demo in the `template-demo` app

## Example

Here is some small, example component that uses the newest syntax:

```ts
@Component({
  selector: 'let-template-binding',
  template: `
    <button [unpatch] (click)="signals$?.complete()">
      complete
    </button>
    <button [unpatch] (click)="signals$?.next(random())">
      next
    </button>
    <button [unpatch] (click)="signals$?.error(errorStub)">
      error
    </button>

    <div
      *rxLet="
        signals$;
        let count;
        strategy: visibleStrategy;
        complete: complete;
        error: error;
        suspense: suspense
      "
    >
      value: {{ count | json }}
    </div>

    <ng-template #complete>
      <h1>COMPLETE</h1>
    </ng-template>
    <ng-template #error>
      <h1>ERROR</h1>
    </ng-template>
    <ng-template #suspense>
      <h1>SUSPENSE</h1>
    </ng-template>
  `,
  changeDetection: ChangeDetectionStrategy.OnPush,
})
export class LetTemplateBindingComponent {
  errorStub = new Error("Test error");

  signals$ = new Subject<any>();
  // signals$ = fromPromise(fetch('https://swapi.dev/api/people/1').then(a => a.json()));
  // signals$ = from([1,2,3,4,5]).pipe(first());

  // signals$ = interval(1000).pipe(
  //   switchMap(() => fromPromise(fetch(`https://swapi.dev/api/people/${Math.floor(Math.random() * 20)}`).then(a => a.json()))),
  //   takeUntil(interval(5000))
  // );

  visibleStrategy = 'local';

  random() {
    return Math.random();
  }
}
```

## Any questions?

Comments are welcome! Feature is also ready to play with, so if you want you can switch to my branch and give it a try.