### PR TITLE
fix(state): fixed selectSlice typing

### DIFF
--- a/apps/experiments/src/app/state/rx-state.menu.ts
+++ b/apps/experiments/src/app/state/rx-state.menu.ts
@@ -20,6 +20,10 @@ export const MENU_ITEMS: MenuItem[] = [
       {
         link: 'connect',
         label: 'Connecting'
+      },
+      {
+        link: 'selectslice',
+        label: 'SelectSlice'
       }
     ]
   }

--- a/apps/experiments/src/app/state/rx-state.module.ts
+++ b/apps/experiments/src/app/state/rx-state.module.ts
@@ -20,6 +20,7 @@ import { RxStateParentSelectionsComponent } from './selections/parent.component'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RxStateChildSelectionsComponent } from './selections/child.component';
 import { RxStateParentSubscriptionLessComponent } from './subscription-less-interaction/parent.component';
+import { RxStateSelectSliceComponent } from './selectslice/select-slice.component';
 
 @NgModule({
   declarations: [
@@ -28,7 +29,8 @@ import { RxStateParentSubscriptionLessComponent } from './subscription-less-inte
     RxStateParentCompositionComponent,
     RxStateParentSelectionsComponent,
     RxStateParentSubscriptionComponent,
-    RxStateParentSubscriptionLessComponent
+    RxStateParentSubscriptionLessComponent,
+    RxStateSelectSliceComponent
   ],
   imports: [
     CommonModule,

--- a/apps/experiments/src/app/state/rx-state.routes.ts
+++ b/apps/experiments/src/app/state/rx-state.routes.ts
@@ -1,4 +1,5 @@
 import { RxStateOverviewComponent } from './rx-state.overview.component';
+import { RxStateSelectSliceComponent } from './selectslice/select-slice.component';
 import { RxStateParentSubscriptionComponent } from './subscription/parent.component';
 import { RxStateParentSelectionsComponent } from './selections/parent.component';
 import { RxStateParentCompositionComponent } from './composition/parent.component';
@@ -24,5 +25,9 @@ export const ROUTES = [
   {
     path: 'connect',
     component: RxStateParentSubscriptionLessComponent
+  },
+  {
+    path: 'selectslice',
+    component: RxStateSelectSliceComponent
   }
 ];

--- a/apps/experiments/src/app/state/selectslice/select-slice.component.html
+++ b/apps/experiments/src/app/state/selectslice/select-slice.component.html
@@ -1,0 +1,1 @@
+<p>{{ viewState$ | async | json }}</p>

--- a/apps/experiments/src/app/state/selectslice/select-slice.component.ts
+++ b/apps/experiments/src/app/state/selectslice/select-slice.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RxState, selectSlice } from '@rx-angular/state';
+import { Observable, of } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
+interface MyState {
+  title: string;
+  list: string[];
+  isItemRendered: boolean;
+}
+
+@Component({
+  selector: 'rx-select-slice',
+  templateUrl: './select-slice.component.html',
+  styleUrls: ['./select-slice.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class RxStateSelectSliceComponent extends RxState<MyState> {
+  readonly viewState$ = this.select(
+    selectSlice(['list', 'isItemRendered']),
+    filter(({ isItemRendered, list }) => !isItemRendered && list.length > 0)
+  );
+
+  constructor() {
+    super();
+    const state$: Observable<MyState> = of(
+      { title: 'myTitle', list: ['foo', 'bar'], isItemRendered: true },
+      { title: 'myTitle', list: ['foo', 'bar'], isItemRendered: false },
+      { title: 'nextTitle', list: ['foo', 'baR'], isItemRendered: true },
+      { title: 'nextTitle', list: ['fooRz', 'boo'], isItemRendered: false }
+    );
+    this.connect(state$);
+  }
+}

--- a/libs/state/spec/rxjs/operators/selectSlice.spec.ts
+++ b/libs/state/spec/rxjs/operators/selectSlice.spec.ts
@@ -61,8 +61,7 @@ describe('selectSlice operator', () => {
       expectObservable(
         e1.pipe(
           selectSlice(['val']),
-          map(({ val }) => ({ val })) // this is here to test if the typings work in strict mode. we had some
-          // struggles ;)
+          map(({ val }) => ({ val })) // this is here to test if the typings work in strict mode
         )
       ).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/libs/state/spec/rxjs/operators/selectSlice.spec.ts
+++ b/libs/state/spec/rxjs/operators/selectSlice.spec.ts
@@ -3,7 +3,7 @@ import { Observable, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { selectSlice } from '../../../src/lib/rxjs/operators/selectSlice';
 import { KeyCompareMap } from '../../../src/lib/rxjs/interfaces';
-import { mergeMap } from 'rxjs/operators';
+import { map, mergeMap } from 'rxjs/operators';
 
 let testScheduler: TestScheduler;
 
@@ -60,7 +60,9 @@ describe('selectSlice operator', () => {
 
       expectObservable(
         e1.pipe(
-          selectSlice(['val'])
+          selectSlice(['val']),
+          map(({ val }) => ({ val })) // this is here to test if the typings work in strict mode. we had some
+          // struggles ;)
         )
       ).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/libs/state/src/lib/rxjs/operators/selectSlice.ts
+++ b/libs/state/src/lib/rxjs/operators/selectSlice.ts
@@ -75,8 +75,8 @@ import { distinctUntilSomeChanged } from './distinctUntilSomeChanged';
 export function selectSlice<T extends object, K extends keyof T>(
   keys: K[],
   keyCompareMap?: KeyCompareMap<{ [P in K]: T[P] }>
-): OperatorFunction<T, PickSlice<T, K> | null> {
-  return (o$: Observable<T>): Observable<PickSlice<T, K> | null> =>
+): OperatorFunction<T, PickSlice<T, K>> {
+  return (o$: Observable<T>): Observable<PickSlice<T, K>> =>
     o$.pipe(
       filter(state => state !== undefined),
       map(state => {


### PR DESCRIPTION
- removed `| null` from selectSlice's typing. this breaks apps which run in strictMode.
- added usage to `selectSlice.spec.ts` to verify typing in strictMode
- added usage in `experiments` app to verify typing in non-strictMode

closes #177 