### PR TITLE
Fix for globalThis issue in old browsers.

### DIFF
--- a/libs/template/src/lib/core/utils/get-global-this.ts
+++ b/libs/template/src/lib/core/utils/get-global-this.ts
@@ -11,5 +11,5 @@
  *  @return {globalThis} - A reference to globalThis. `window` in the Browser.
  */
 export function getGlobalThis(): any {
-  return ((globalThis as any) || (self as any) || (window as any)) as any;
+  return ((window as any) || (self as any) || (globalThis as any)) as any;
 }


### PR DESCRIPTION
Should close #66  

Simply changed return order in getGlobalThis to ```((window as any) || (self as any) || (globalThis as any))```. 

Tested in stateDemo/demo-basics.

What was checked:
- Push pipe
- RxLet
- Unpatch

Tested environments:
- ✔️ Chrome 69 (not supporting globalThis)
- ✔️ Edge 44 (not supporting globalThis)
- ✔️ Our jest tests

What wasn't checked:
- 🤞  SSR. In theory, it should work because both window and self will be undefined. And there probably will be [domino](https://www.npmjs.com/package/domino) or something similar.
- ❌ IE 11. State demo not launching there. But the only problem in IE was the lack of support for globalThis. Overall template package works in IE with polyfill for globalThis.

Hope I'm not missing anything.