### PR TITLE
Fix es5 builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "jest-preset-angular": "8.1.2",
     "klaw-sync": "^6.0.0",
     "lint-staged": "^10.1.6",
-    "ng-packagr": "^10.0.0",
+    "ng-packagr": "^9.1.5",
     "prettier": "2.0.5",
     "ts-jest": "25.2.1",
     "ts-node": "~7.0.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "es2015",
-    "module": "es2020",
+    "module": "esnext",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"],
     "skipLibCheck": true,


### PR DESCRIPTION
Downgraded to `ng-packagr 9.1.5`.
See changelog: https://github.com/ng-packagr/ng-packagr/blob/master/CHANGELOG.md#1000-next0-2020-05-06