### PR TITLE
Scheduling change detection on error and complete and aborting on teardown

### DIFF
--- a/libs/template/spec/let/let.directive.template-binding.all.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.all.spec.ts
@@ -56,8 +56,6 @@ describe('LetDirective when template binding with all templates', () => {
   it('should render "complete" template on the observable completion', () => {
     // The resulting synchronous notification sequence is: 1,2,3,complete
     component.value$ = of(1, 2, 3);
-    // The resulting synchronous notification sequence is: 1,2,3,complete 
-    component.value$ = of(1,2,3);
     fixture.detectChanges();
     expectContentToBe('complete');
   });

--- a/libs/template/src/lib/core/render-aware/finalizeWithScheduledCD.ts
+++ b/libs/template/src/lib/core/render-aware/finalizeWithScheduledCD.ts
@@ -1,9 +1,4 @@
-import {
-  MonoTypeOperatorFunction,
-  NextObserver,
-  Observable,
-  Subscriber,
-} from 'rxjs';
+import { MonoTypeOperatorFunction, Observable, Subscriber } from 'rxjs';
 import { RenderStrategy } from './interfaces';
 
 /**
@@ -11,11 +6,11 @@ import { RenderStrategy } from './interfaces';
  * for the view and cancellation of this scheduled CD on teardown.
  *
  * @param strategy
- * @param viewUpdateObserver observer defining logic for the view update on observable notification(s)
+ * @param config determines whether change detection should be triggered on error and/or complete
  */
 export function finalizeWithScheduledCD<T>(
   strategy: RenderStrategy,
-  viewUpdateObserver: NextObserver<T>
+  config = { scheduleOnError: true, scheduleOnComplete: true }
 ): MonoTypeOperatorFunction<T> {
   return (o$: Observable<T>) =>
     new Observable((subscriber: Subscriber<T>) => {
@@ -23,13 +18,13 @@ export function finalizeWithScheduledCD<T>(
       const subscription = o$.subscribe({
         error: (err) => {
           subscriber.error(err);
-          if (viewUpdateObserver.error) {
+          if (config.scheduleOnError) {
             abortController = strategy.scheduleCD();
           }
         },
         complete: () => {
           subscriber.complete();
-          if (viewUpdateObserver.complete) {
+          if (config.scheduleOnComplete) {
             abortController = strategy.scheduleCD();
           }
         },

--- a/libs/template/src/lib/core/render-aware/finalizeWithScheduledCD.ts
+++ b/libs/template/src/lib/core/render-aware/finalizeWithScheduledCD.ts
@@ -1,0 +1,43 @@
+import {
+  MonoTypeOperatorFunction,
+  NextObserver,
+  Observable,
+  Subscriber,
+} from 'rxjs';
+import { RenderStrategy } from './interfaces';
+
+/**
+ * Operator that handles scheduling change detection on error and complete observable notifications
+ * for the view and cancellation of this scheduled CD on teardown.
+ *
+ * @param strategy
+ * @param viewUpdateObserver observer defining logic for the view update on observable notification(s)
+ */
+export function finalizeWithScheduledCD<T>(
+  strategy: RenderStrategy,
+  viewUpdateObserver: NextObserver<T>
+): MonoTypeOperatorFunction<T> {
+  return (o$: Observable<T>) =>
+    new Observable((subscriber: Subscriber<T>) => {
+      let abortController: AbortController;
+      const subscription = o$.subscribe({
+        error: (err) => {
+          subscriber.error(err);
+          if (viewUpdateObserver.error) {
+            abortController = strategy.scheduleCD();
+          }
+        },
+        complete: () => {
+          subscriber.complete();
+          if (viewUpdateObserver.complete) {
+            abortController = strategy.scheduleCD();
+          }
+        },
+      });
+      return () => {
+        subscription.unsubscribe();
+        // cancel any scheduled CD on teardown
+        abortController?.abort();
+      };
+    });
+}

--- a/libs/template/src/lib/core/render-aware/index.ts
+++ b/libs/template/src/lib/core/render-aware/index.ts
@@ -2,3 +2,4 @@ export * from './render-aware_creator';
 export * from './nameToStrategy';
 export * from './interfaces';
 export * from './coalescing-manager';
+export * from './finalizeWithScheduledCD';

--- a/libs/template/src/lib/core/render-aware/render-aware_creator.ts
+++ b/libs/template/src/lib/core/render-aware/render-aware_creator.ts
@@ -5,7 +5,7 @@ import {
   of,
   ReplaySubject,
   Subscribable,
-  Subscription
+  Subscription,
 } from 'rxjs';
 import {
   catchError,
@@ -13,8 +13,9 @@ import {
   filter,
   map,
   switchMap,
-  tap
+  tap,
 } from 'rxjs/operators';
+import { finalizeWithScheduledCD } from './finalizeWithScheduledCD';
 import { RenderStrategy, StrategySelection } from './interfaces';
 import { nameToStrategy } from './nameToStrategy';
 
@@ -42,13 +43,13 @@ export function createRenderAware<U>(cfg: {
   let currentStrategy: RenderStrategy;
   const strategy$: Observable<RenderStrategy> = strategyName$.pipe(
     distinctUntilChanged(),
-    switchMap(stringOrObservable =>
+    switchMap((stringOrObservable) =>
       typeof stringOrObservable === 'string'
         ? of(stringOrObservable)
         : stringOrObservable
     ),
     nameToStrategy(cfg.strategies),
-    tap(s => (currentStrategy = s))
+    tap((s) => (currentStrategy = s))
   );
 
   const observablesFromTemplate$ = new ReplaySubject<Observable<U>>(1);
@@ -59,7 +60,7 @@ export function createRenderAware<U>(cfg: {
 
   const renderingEffect$ = valuesFromTemplate$.pipe(
     // handle null | undefined assignment and new Observable reset
-    map(observable$ => {
+    map((observable$) => {
       if (observable$ === null) {
         return of(null);
       }
@@ -73,28 +74,17 @@ export function createRenderAware<U>(cfg: {
       return observable$;
     }),
     // forward only observable values
-    filter(o$ => o$ !== undefined),
-    switchMap(o$ =>
+    filter((o$) => o$ !== undefined),
+    switchMap((o$) =>
       o$.pipe(
         distinctUntilChanged(),
         tap(cfg.updateObserver),
         currentStrategy.rxScheduleCD,
-        tap({
-          // handle "error" and "complete" notifications for Observable from template
-          error: err => {
-            console.error(err);
-            if (cfg.updateObserver.error) {
-              cfg.updateObserver.error(err);
-              currentStrategy.detectChanges();
-            }
-          },
-          complete: cfg.updateObserver.complete
-            ? () => currentStrategy.detectChanges()
-            : undefined
-        })
+        finalizeWithScheduledCD(currentStrategy, cfg.updateObserver)
       )
     ),
-    catchError(e => {
+    catchError((e) => {
+      console.error(e);
       return EMPTY;
     })
   );
@@ -111,6 +101,6 @@ export function createRenderAware<U>(cfg: {
       return new Subscription()
         .add(strategy$.subscribe())
         .add(renderingEffect$.subscribe());
-    }
+    },
   };
 }

--- a/libs/template/src/lib/core/render-aware/render-aware_creator.ts
+++ b/libs/template/src/lib/core/render-aware/render-aware_creator.ts
@@ -80,7 +80,10 @@ export function createRenderAware<U>(cfg: {
         distinctUntilChanged(),
         tap(cfg.updateObserver),
         currentStrategy.rxScheduleCD,
-        finalizeWithScheduledCD(currentStrategy, cfg.updateObserver)
+        finalizeWithScheduledCD(currentStrategy, {
+          scheduleOnError: !!cfg.updateObserver.error,
+          scheduleOnComplete: !!cfg.updateObserver.complete,
+        })
       )
     ),
     catchError((e) => {


### PR DESCRIPTION
## Problem

When using `rxLet` directive and binding an observable to it, internally, change detection is scheduled whenever an observable notification (next/error/complete) is sent. There's a possibility (a slight, but...) that a notification is sent and before the actual change detection is triggered, the component is destroyed and stops existing. In other words - change detection is triggered on the non-existing component. That may result with errors or unexpected behaviors.

The other problem this PR solves is triggering change detection on error and complete notifications by using `RenderStrategy#detectChanges` method instead `RenderStrategy#scheduleCD`. By using the second one we gain some rendering optimizations specific for the provided rendering strategy. 

## How to reproduce?

The best way to actually see it is to change `libs/template/src/lib/core/render-aware/render-aware_creator.ts`, lines 88 and 92 (`master` branch) and use `scheduleCD()` method instead of `detectChanged()`. 

```ts
// libs/template/src/lib/core/render-aware/render-aware_creator.ts

...
tap({
// handle "error" and "complete" notifications for Observable from template
  error: err => {
    console.error(err);
    if (cfg.updateObserver.error) {
      cfg.updateObserver.error(err);
      currentStrategy.detectChanges(); // change to --> currentStrategy.scheduleCD();
    }
  },
  complete: cfg.updateObserver.complete
    ? () => currentStrategy.detectChanges() // change to --> currentStrategy.scheduleCD();
    : undefined
})
...
```

Tests start to fail on assertions from the `detectChanges` function from the core Angular. This is because Angular is not happy with triggering change detection on component that doesn't actually exist anymore. Tests are so fast, that they destroy a component under test before the final change detection happens.

## Solution

Solution is to define some custom teardown logic for an observable from the view and abort scheduled CD there. This is done with a custom `finalizeWithScheduledCD` operator.