### PR TITLE
Fixed inferring type from a subtype of a state provided for RxState

### DIFF
--- a/libs/state/src/lib/rxjs/operators/selectSlice.ts
+++ b/libs/state/src/lib/rxjs/operators/selectSlice.ts
@@ -113,5 +113,5 @@ export function selectSlice<T extends object, K extends keyof T>(
 
 type PickSlice<T extends object, K extends keyof T> = Pick<
   T,
-  { [I in keyof T]: I }[K]
+  { [I in K]: I }[K]
 >;


### PR DESCRIPTION
## Issue

The goal of this PR is to fix https://github.com/BioPhoton/rx-angular/issues/177. As provided by the author within his playground demo, `selectSlice` incorrectly infers the type of a slice when the type provided to `RxState` declaration is not a concrete type but a generic subtype of one.

## Example

To verify if the `selectSlice` does what it is supposed to, I created a small example that can be played with even inside our own RxAngular repo.

```typescript
interface MyState {
  title: string;
  items: string[];
  panelOpen: boolean;
}

const state$: Observable<MyState> = of({
  items: [''],
  panelOpen: true,
  title: 'dwadaw'
});

// typical use-case, `data` should be of the correct type
const slice$ = state$.pipe(
  selectSlice(['items'])
).subscribe(data => data.items);

// example from christianacca reproduced, simplified
class AppComp<T extends MyState> {
  constructor(protected state: RxState<T>) {
    const a = this.state.select().pipe(
      selectSlice(['title']),
      filter(({ title }) => true)
    );
  }
}
```

When verifying, please do it also for `strictNullChecks` compiler options set to `false`. The most problems with type inference come up with this option.