### PR TITLE
docs(test-coverage): added test coverage to docs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
+/docs
 /dist
 /tmp
 /out-tsc

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/docs
 /dist
 /tmp
 /out-tsc

--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,9 @@
               "apps/state-demo/src/favicon.ico",
               "apps/state-demo/src/assets"
             ],
-            "styles": ["apps/state-demo/src/styles.scss"],
+            "styles": [
+              "apps/state-demo/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -126,7 +128,10 @@
               "apps/state-demo/tsconfig.app.json",
               "apps/state-demo/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!apps/state-demo/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/state-demo/**/*"
+            ]
           }
         },
         "test": {
@@ -223,7 +228,10 @@
               "apps/experiments/tsconfig.app.json",
               "apps/experiments/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!apps/experiments/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/experiments/**/*"
+            ]
           }
         },
         "test": {
@@ -248,7 +256,10 @@
               "libs/test-helpers/tsconfig.lib.json",
               "libs/test-helpers/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!libs/test-helpers/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/test-helpers/**/*"
+            ]
           }
         },
         "test": {
@@ -285,7 +296,10 @@
               "libs/state/tsconfig.lib.json",
               "libs/state/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!libs/state/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/state/**/*"
+            ]
           }
         },
         "test": {
@@ -293,6 +307,34 @@
           "options": {
             "jestConfig": "libs/state/jest.config.js",
             "passWithNoTests": true
+          }
+        },
+        "build-docs": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              {
+                "command": "nx test-coverage state && nx test-coverage-badge state"
+              }
+            ]
+          }
+        },
+        "test-coverage-badge": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              {
+                "command": "npx istanbul-cobertura-badger -b jest-coverage-badge -r ./docs/test-coverage/state/cobertura-coverage.xml -d docs/test-coverage/state"
+              }
+            ]
+          }
+        },
+        "test-coverage": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/state/jest.config.js",
+            "passWithNoTests": true,
+            "codeCoverage": true
           }
         },
         "perfBuild": {
@@ -341,7 +383,10 @@
               "libs/template/tsconfig.lib.json",
               "libs/template/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!libs/template/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/template/**/*"
+            ]
           }
         },
         "test": {
@@ -349,6 +394,35 @@
           "options": {
             "jestConfig": "libs/template/jest.config.js",
             "passWithNoTests": true
+          }
+        },
+        "build-docs": {
+          "builder": "@nrwl/workspace:run-commands",
+          "sequential": true,
+          "options": {
+            "commands": [
+              {
+                "command": "nx test-coverage template && nx test-coverage-badge template"
+              }
+            ]
+          }
+        },
+        "test-coverage-badge": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              {
+                "command": "npx istanbul-cobertura-badger -b jest-coverage-badge -r ./docs/test-coverage/template/cobertura-coverage.xml -d docs/test-coverage/template"
+              }
+            ]
+          }
+        },
+        "test-coverage": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/template/jest.config.js",
+            "passWithNoTests": true,
+            "codeCoverage": true
           }
         }
       },
@@ -382,7 +456,9 @@
               "apps/template-demo/src/favicon.ico",
               "apps/template-demo/src/assets"
             ],
-            "styles": ["apps/template-demo/src/styles.scss"],
+            "styles": [
+              "apps/template-demo/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -440,7 +516,10 @@
               "apps/template-demo/tsconfig.app.json",
               "apps/template-demo/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!apps/template-demo/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/template-demo/**/*"
+            ]
           }
         },
         "test": {
@@ -472,8 +551,13 @@
             "polyfills": "apps/docs/src/polyfills.ts",
             "tsConfig": "apps/docs/tsconfig.app.json",
             "aot": true,
-            "assets": ["apps/docs/src/favicon.ico", "apps/docs/src/assets"],
-            "styles": ["apps/docs/src/styles.scss"],
+            "assets": [
+              "apps/docs/src/favicon.ico",
+              "apps/docs/src/assets"
+            ],
+            "styles": [
+              "apps/docs/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -531,7 +615,10 @@
               "apps/docs/tsconfig.app.json",
               "apps/docs/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!apps/docs/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/docs/**/*"
+            ]
           }
         },
         "test": {
@@ -567,7 +654,9 @@
               "apps/tour-of-heroes/src/favicon.ico",
               "apps/tour-of-heroes/src/assets"
             ],
-            "styles": ["apps/tour-of-heroes/src/styles.scss"],
+            "styles": [
+              "apps/tour-of-heroes/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -636,7 +725,10 @@
               "apps/tour-of-heroes/tsconfig.app.json",
               "apps/tour-of-heroes/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!apps/tour-of-heroes/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/tour-of-heroes/**/*"
+            ]
           }
         },
         "test": {
@@ -672,7 +764,9 @@
               "apps/tour-of-heroes-ngxs/src/favicon.ico",
               "apps/tour-of-heroes-ngxs/src/assets"
             ],
-            "styles": ["apps/tour-of-heroes-ngxs/src/styles.scss"],
+            "styles": [
+              "apps/tour-of-heroes-ngxs/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -705,7 +799,9 @@
               ]
             },
             "zoneless": {
-              "polyfills": ["apps/tour-of-heroes-ngxs/src/polyfills.ts"],
+              "polyfills": [
+                "apps/tour-of-heroes-ngxs/src/polyfills.ts"
+              ],
               "fileReplacements": [
                 {
                   "replace": "apps/tour-of-heroes/src/environments/environment.ts",
@@ -742,7 +838,10 @@
               "apps/tour-of-heroes-ngxs/tsconfig.app.json",
               "apps/tour-of-heroes-ngxs/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!apps/tour-of-heroes-ngxs/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/tour-of-heroes-ngxs/**/*"
+            ]
           }
         },
         "test": {

--- a/libs/state/jest.config.js
+++ b/libs/state/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   name: '@rx-angular/state',
   preset: '../../jest.config.js',
-  coverageDirectory: '../../coverage/state',
+  coverageReporters: ['lcov', 'cobertura'],
+  coverageDirectory: '../../docs/test-coverage/state',
   collectCoverageFrom: ['./src/**/*.ts'],
   snapshotSerializers: [
     'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',

--- a/libs/template/jest.config.js
+++ b/libs/template/jest.config.js
@@ -1,8 +1,9 @@
 module.exports = {
-  name: 'template',
+  name: '@rx-angular/template',
   preset: '../../jest.config.js',
-  coverageDirectory: '../../coverage/template',
-  collectCoverageFrom: ['./src/**/*.ts'],
+  coverageReporters: ['lcov', 'cobertura'],
+  coverageDirectory: '../../docs/test-coverage/template',
+  collectCoverageFrom: ['./src/**/!(experimental)/*.ts'],
   snapshotSerializers: [
     'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
     'jest-preset-angular/build/AngularSnapshotSerializer.js',


### PR DESCRIPTION
This PR implements testbade generation and moves the output in the docs folder.

This has a couple of implications
- This means we would self host our test coverage bades
- We can have badges per repo
- we can hose Istambul output as-is
- we lose/drop corealls
- we have to integrate test-docs generation in the release step 

Let me know your thoughts on that.