### PR TITLE
Mock console in tests

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -305,6 +305,7 @@
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
+            "tsConfig": "libs/state/tsconfig.spec.json",
             "jestConfig": "libs/state/jest.config.js",
             "passWithNoTests": true
           }
@@ -392,6 +393,7 @@
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
+            "tsConfig": "libs/template/tsconfig.spec.json",
             "jestConfig": "libs/template/jest.config.js",
             "passWithNoTests": true
           }

--- a/libs/template/spec/core/render-aware/render-aware_creator.spec.ts
+++ b/libs/template/spec/core/render-aware/render-aware_creator.spec.ts
@@ -2,6 +2,7 @@ import { OnDestroy } from '@angular/core';
 import { createRenderAware, RenderAware } from '../../../src/lib/core';
 import { concat, EMPTY, NEVER, NextObserver, Observer, of, Unsubscribable } from 'rxjs';
 import { DEFAULT_STRATEGY_NAME } from '../../../src/lib/render-strategies/strategies/strategies-map';
+import { mockConsole } from '@test-helpers';
 
 // TODO: Add Angular decorator.
 class CdAwareImplementation<U> implements OnDestroy {
@@ -51,7 +52,10 @@ const setupCdAwareImplementation = () => {
   cdAwareImplementation.completed = false;
 };
 
+
 describe('CdAware', () => {
+  beforeAll(() => mockConsole());
+
   beforeEach(() => {
     setupCdAwareImplementation();
   });

--- a/libs/template/spec/core/utils/create_properties-weakmap.spec.ts
+++ b/libs/template/spec/core/utils/create_properties-weakmap.spec.ts
@@ -1,4 +1,5 @@
 import { createPropertiesWeakMap } from '../../../src/lib/core/utils';
+import { mockConsole } from '@test-helpers';
 
 const propertyNameString = 'flag';
 const propertyNameSymbol = Symbol('flag');
@@ -10,11 +11,14 @@ const initialContextObjectState = {
   flag: 'original value'
 };
 
+
 //  **NOTICE:**
 //  [WeakMaps](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap)
 //  don't hold hard references, so garbage collection will happen
 
 describe('propertiesWeakMap', () => {
+  beforeAll(() => mockConsole());
+
   beforeEach(() => {
     contextObject = { ...initialContextObjectState };
   });

--- a/libs/template/spec/core/utils/get-global-this.spec.ts
+++ b/libs/template/spec/core/utils/get-global-this.spec.ts
@@ -1,6 +1,10 @@
 import { getGlobalThis } from '../../../src/lib/core';
+import { mockConsole } from '@test-helpers';
+
 
 describe('getGlobalThis', () => {
+  beforeAll(() => mockConsole());
+
   it('should return global this', () => {
     getGlobalThis().prop = 42;
     const globalThis = getGlobalThis();

--- a/libs/template/spec/core/utils/view-engine-checks.spec.ts
+++ b/libs/template/spec/core/utils/view-engine-checks.spec.ts
@@ -1,6 +1,10 @@
 import { getGlobalThis, isViewEngineIvy } from '../../../src/lib/core';
+import { mockConsole } from '@test-helpers';
+
 
 describe('isIvy', () => {
+  beforeAll(() => mockConsole());
+
   describe('in ViewEngine Angular 8 + 9', () => {
     it('should return false if ng is defined with probe', () => {
       getGlobalThis().ng = { probe: true };

--- a/libs/template/spec/core/utils/zone-check.spec.ts
+++ b/libs/template/spec/core/utils/zone-check.spec.ts
@@ -2,8 +2,12 @@ import { ApplicationRef, Component, NgModule, NgZone } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { isNgZone, isNoopNgZone } from '../../../src/lib/core/utils';
+import { mockConsole } from '@test-helpers';
+
 
 describe('hasZone', () => {
+  beforeAll(() => mockConsole());
+
   async function setup({ defaultZone }: { defaultZone: boolean }) {
     @Component({
       // tslint:disable-next-line:component-selector

--- a/libs/template/spec/let/let.directive.complete.spec.ts
+++ b/libs/template/spec/let/let.directive.complete.spec.ts
@@ -3,6 +3,7 @@ import { EMPTY, Observable, of } from 'rxjs';
 import { async, TestBed } from '@angular/core/testing';
 import { LetDirective } from '../../src/lib/let';
 import { MockChangeDetectorRef } from '../fixtures';
+import { mockConsole } from '@test-helpers';
 
 @Component({
   template: `
@@ -41,6 +42,7 @@ const setupLetDirectiveTestComponentComplete = (): void => {
 };
 
 describe('LetDirective when complete', () => {
+  beforeAll(() => mockConsole());
   beforeEach(async(setupLetDirectiveTestComponentComplete));
 
   it('should render true if completed', () => {

--- a/libs/template/spec/let/let.directive.error.spec.ts
+++ b/libs/template/spec/let/let.directive.error.spec.ts
@@ -3,6 +3,7 @@ import { Observable, of, throwError } from 'rxjs';
 import { async, TestBed } from '@angular/core/testing';
 import { LetDirective } from '../../src/lib/let';
 import { MockChangeDetectorRef } from '../fixtures';
+import { mockConsole } from '@test-helpers';
 
 @Component({
   template: `
@@ -39,6 +40,7 @@ let letDirectiveTestComponent: {
 let componentNativeElement: any;
 
 describe('LetDirective when error', () => {
+  beforeAll(() => mockConsole());
   beforeEach(async(setupLetDirectiveTestComponentError));
 
   it('should render the error to false if next or complete', () => {

--- a/libs/template/spec/let/let.directive.next.spec.ts
+++ b/libs/template/spec/let/let.directive.next.spec.ts
@@ -4,6 +4,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { LetDirective } from '../../src/lib/let';
 import { take } from 'rxjs/operators';
 import { MockChangeDetectorRef } from '../fixtures';
+import { mockConsole } from '@test-helpers';
 
 @Component({
   template: `
@@ -46,6 +47,7 @@ const setupLetDirectiveTestComponent = (): void => {
 };
 
 describe('LetDirective when nexting values', () => {
+  beforeAll(() => mockConsole());
   beforeEach((setupLetDirectiveTestComponent));
 
   it('should be instantiable', () => {

--- a/libs/template/spec/let/let.directive.strategy.spec.ts
+++ b/libs/template/spec/let/let.directive.strategy.spec.ts
@@ -3,6 +3,7 @@ import { Observable, of } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
 import { LetDirective } from '../../src/lib/let';
 import { MockChangeDetectorRef } from '../fixtures';
+import { mockConsole } from '@test-helpers';
 
 @Component({
   template: `
@@ -41,6 +42,7 @@ const setupLetDirectiveTestComponentStrategy = (): void => {
 };
 
 describe('LetDirective when using strategy', () => {
+  beforeAll(() => mockConsole());
   beforeEach(setupLetDirectiveTestComponentStrategy);
 
   it('should work with different if a strategy other than the default', () => {

--- a/libs/template/spec/let/let.directive.template-binding.all.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.all.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core
 import { LetDirective } from '@rx-angular/template';
 import { EMPTY, interval, Observable, of, Subject, NEVER, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
+import { mockConsole } from '@test-helpers';
 
 @Component({
   template: `
@@ -40,6 +41,7 @@ const setUpFixture = () => {
 };
 
 describe('LetDirective when template binding with all templates', () => {
+  beforeAll(() => mockConsole());
   beforeEach(async(setupTestComponent));
   beforeEach(setUpFixture);
 
@@ -56,7 +58,7 @@ describe('LetDirective when template binding with all templates', () => {
   it('should render "complete" template on the observable completion', () => {
     // The resulting synchronous notification sequence is: 1,2,3,complete
     component.value$ = of(1, 2, 3);
-    // The resulting synchronous notification sequence is: 1,2,3,complete 
+    // The resulting synchronous notification sequence is: 1,2,3,complete
     component.value$ = of(1,2,3);
     fixture.detectChanges();
     expectContentToBe('complete');

--- a/libs/template/spec/let/let.directive.template-binding.no-complete.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.no-complete.spec.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LetDirective } from '@rx-angular/template';
 import { EMPTY, Observable, of } from 'rxjs';
+import { mockConsole } from '@test-helpers';
 
 @Component({
   template: `
@@ -38,6 +39,7 @@ const setUpFixture = () => {
 };
 
 describe('LetDirective when template binding without "complete" template', () => {
+  beforeAll(() => mockConsole());
   beforeEach(async(setupTestComponent));
   beforeEach(setUpFixture);
 

--- a/libs/template/spec/let/let.directive.template-binding.no-error.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.no-error.spec.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LetDirective } from '@rx-angular/template';
 import { Observable, of, Subject } from 'rxjs';
+import { mockConsole } from '@test-helpers';
 
 @Component({
   template: `
@@ -38,6 +39,7 @@ const setUpFixture = () => {
 };
 
 describe('LetDirective when template binding without "error" template', () => {
+  beforeAll(() => mockConsole());
   beforeEach(async(setupTestComponent));
   beforeEach(setUpFixture);
 

--- a/libs/template/spec/let/let.directive.template-binding.no-suspense.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.no-suspense.spec.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LetDirective } from '@rx-angular/template';
 import { Observable, of, Subject } from 'rxjs';
+import { mockConsole } from '@test-helpers';
 
 @Component({
   template: `
@@ -39,6 +40,7 @@ const setUpFixture = () => {
 };
 
 describe('LetDirective when template binding without "suspense" template', () => {
+  beforeAll(() => mockConsole());
   beforeEach(async(setupTestComponent));
   beforeEach(setUpFixture);
 

--- a/libs/template/spec/push/push.pipe.service.spec.ts
+++ b/libs/template/spec/push/push.pipe.service.spec.ts
@@ -4,6 +4,7 @@ import { ChangeDetectorRef, Component } from '@angular/core';
 import { getGlobalThis } from '../../src/lib/core/utils';
 import { EMPTY, NEVER, Observable, of } from 'rxjs';
 import { MockChangeDetectorRef } from '../fixtures';
+import { mockConsole } from '@test-helpers';
 
 let pushPipe: any;
 
@@ -18,6 +19,7 @@ const setupPushPipeComponent = () => {
 };
 
 describe('PushPipe used as a Service', () => {
+  beforeAll(() => mockConsole());
   beforeEach(async(setupPushPipeComponent));
 
   it('should be instantiable', () => {

--- a/libs/template/spec/push/push.pipe.spec.ts
+++ b/libs/template/spec/push/push.pipe.spec.ts
@@ -2,6 +2,7 @@ import { PushPipe } from '../../src/lib/push';
 import { TestBed } from '@angular/core/testing';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { EMPTY, NEVER, Observable, of } from 'rxjs';
+import { mockConsole } from '@test-helpers';
 
 function wrapWithSpace(str: string): string {
   return ' ' + str + ' ';
@@ -46,6 +47,8 @@ const setupPushPipeComponent = () => {
 };
 
 describe('PushPipe used as pipe in the template', () => {
+  beforeAll(() => mockConsole());
+
   beforeEach(setupPushPipeComponent);
 
   it('should be instantiable', () => {

--- a/libs/template/spec/render-strategies/experiments/task-time.spec.ts
+++ b/libs/template/spec/render-strategies/experiments/task-time.spec.ts
@@ -1,5 +1,9 @@
+import { mockConsole } from "@test-helpers";
+
+
 /** @test {coalesceWith} */
 describe('execution order', () => {
+  beforeAll(() => mockConsole());
 
   it('task, micro, macro', (done) => {
     const executionOrder = [1, 2, 3];

--- a/libs/template/spec/render-strategies/rxjs/coalesceWith.spec.ts
+++ b/libs/template/spec/render-strategies/rxjs/coalesceWith.spec.ts
@@ -3,11 +3,14 @@ import { mergeMapTo, share } from 'rxjs/operators';
 import { concat, defer, from, of, timer } from 'rxjs';
 
 // tslint:disable-next-line:nx-enforce-module-boundaries
-import { jestMatcher } from '@test-helpers';
+import { jestMatcher, mockConsole } from '@test-helpers';
 import { coalesceWith } from '../../../src/lib/render-strategies/rxjs/operators/coalesceWith';
+
 
 /** @test {coalesceWith} */
 describe('coalesce operator additional logic', () => {
+  beforeAll(() => mockConsole());
+
   let testScheduler: TestScheduler;
 
   beforeEach(() => {

--- a/libs/template/spec/render-strategies/static/static-coalesce.spec.ts
+++ b/libs/template/spec/render-strategies/static/static-coalesce.spec.ts
@@ -1,9 +1,11 @@
 import { staticCoalesce } from '../../../src/lib/render-strategies/static';
 import { priorityTickMap, SchedulingPriority } from '@rx-angular/template';
 import { from } from 'rxjs';
+import { mockConsole } from '@test-helpers';
 
 /** @test {coalesceWith} */
 describe('staticCoalesce', () => {
+  beforeAll(() => mockConsole());
 
   it('should coalesce to a scope', (done) => {
     let test = 0;

--- a/libs/template/spec/render-strategies/static/static-schedule-and-coalesced.spec.ts
+++ b/libs/template/spec/render-strategies/static/static-schedule-and-coalesced.spec.ts
@@ -1,8 +1,10 @@
 import { coalesceAndSchedule } from '../../../src/lib/render-strategies/static';
 import { SchedulingPriority } from '../../../src/lib/render-strategies/rxjs/scheduling/interfaces';
+import { mockConsole } from '@test-helpers';
 
 /** @test {coalesceWith} */
 describe('schedule and coalesce', () => {
+  beforeAll(() => mockConsole());
 
   it('should change the execution context for coalescing', (done) => {
     let test = 0;

--- a/libs/template/spec/render-strategies/static/static-schedule.spec.ts
+++ b/libs/template/spec/render-strategies/static/static-schedule.spec.ts
@@ -1,8 +1,10 @@
 import { staticSchedule } from '../../../src/lib/render-strategies/static';
 import { SchedulingPriority } from '../../../src/lib/render-strategies/rxjs/scheduling';
+import { mockConsole } from '@test-helpers';
 
 
 describe('staticSchedule', () => {
+  beforeAll(() => mockConsole());
 
   it('should change the execution context', (done) => {
     let test = 0;

--- a/libs/template/spec/render-strategies/strategy.spec.ts
+++ b/libs/template/spec/render-strategies/strategy.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '../../src/lib/render-strategies';
 import { TestScheduler } from 'rxjs/testing';
 // tslint:disable-next-line:nx-enforce-module-boundaries
-import { jestMatcher } from '@test-helpers';
+import { jestMatcher, mockConsole } from '@test-helpers';
 
 import {
   getMockNativeStrategyConfig,
@@ -39,7 +39,10 @@ function tickFromUnPatchedPromise() {
   return from(getUnpatchedResolvedPromise());
 }
 
+
 describe('getZoneUnPatchedDurationSelector', () => {
+  beforeAll(() => mockConsole());
+
   beforeEach(restoreGlobalThis);
 
   it('should return the the native/un-patched Promise from globalThis.Promise if zone didnt patch it', () => {

--- a/libs/test-helpers/src/lib/utils/index.ts
+++ b/libs/test-helpers/src/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './mutation-manager';
+export * from './mock-console';

--- a/libs/test-helpers/src/lib/utils/mock-console.ts
+++ b/libs/test-helpers/src/lib/utils/mock-console.ts
@@ -1,0 +1,9 @@
+export const mockConsole = (methods?: ('log' | 'warn' | 'error')[]) => {
+  if (methods) {
+    return methods.forEach(m => jest.spyOn(console, m).mockImplementation());
+  }
+
+  jest.spyOn(console, 'log').mockImplementation();
+  jest.spyOn(console, 'warn').mockImplementation();
+  jest.spyOn(console, 'error').mockImplementation();
+};


### PR DESCRIPTION
## Mock console in tests

### What Problem/Issue is it trying to solve?

Now if you run template tests console output will be overwhelmed with `console.error` output. Solution for this is to mock console implementation with `jest.spyOn(console, 'error').mockImplementation()`.

### Change List

- Test commands were not working (neither in this branch or master). To fix that I've extended `angular.json` a little bit. Paths to `tsconfig.spec.json` were added to state -> test -> options and template -> test -> options.
- `mockConsole` method added to `test-helpers/src/lib/utils/mock-console.ts`
- All template tests now importing this helper and running it in jest `beforeAll` inside main `describe` blocks.

### How to Test it

run `yarn run nx test template` & `yarn run nx test state`.

 