### PR TITLE
Handling of error and complete notifications for LetDirective (and more)

### DIFF
--- a/apps/template-demo/src/app/examples/template-binding/let-template-binding/examples/let-template-binding-subject-example.component.ts
+++ b/apps/template-demo/src/app/examples/template-binding/let-template-binding/examples/let-template-binding-subject-example.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { scan, startWith } from 'rxjs/operators';
 
 @Component({
@@ -8,6 +8,9 @@ import { scan, startWith } from 'rxjs/operators';
     <mat-card class="card">
       <mat-card-header>
         <h1>Subject</h1>
+        <button class="btn-reset" mat-button (click)="reset()">
+          <mat-icon>refresh</mat-icon>RESET
+        </button>
       </mat-card-header>
 
       <mat-card-content>
@@ -47,13 +50,13 @@ import { scan, startWith } from 'rxjs/operators';
 
     <ng-template #complete>
       <div>
-        <mat-icon class="complete-icon">thumb_up</mat-icon>
+        <mat-icon class="notification-icon complete-icon">thumb_up</mat-icon>
         <h2>Completed!</h2>
       </div>
     </ng-template>
     <ng-template #error>
       <div>
-        <mat-icon class="error-icon">thumb_down</mat-icon>
+        <mat-icon class="notification-icon error-icon">thumb_down</mat-icon>
         <h2>Something went wrong...</h2>
       </div>
     </ng-template>
@@ -67,6 +70,10 @@ import { scan, startWith } from 'rxjs/operators';
   `,
   styles: [
     `
+      h1 {
+        margin: 0;
+      }
+
       mat-card-content {
         min-height: 10rem;
         display: flex;
@@ -74,10 +81,14 @@ import { scan, startWith } from 'rxjs/operators';
         align-items: center;
       }
 
-      mat-icon {
+      .notification-icon {
         font-size: 5rem;
         height: initial;
         width: initial;
+      }
+
+      .btn-reset {
+        margin-left: 6rem;
       }
 
       .card {
@@ -93,19 +104,28 @@ import { scan, startWith } from 'rxjs/operators';
       .error-icon {
         color: darkred;
       }
-    `
-  ]
+    `,
+  ],
 })
 export class LetTemplateBindingSubjectExampleComponent {
   errorStub = new Error('Template observable error!');
   visibleStrategy = 'local';
-  signals$ = new Subject<any>();
-  signalsCount$ = this.signals$.pipe(
-    scan(acc => acc + 1, 0),
-    startWith(0)
-  );
+  signals$: Subject<number>;
+  signalsCount$: Observable<number>;
+
+  constructor() {
+    this.reset();
+  }
 
   random() {
     return Math.random();
+  }
+
+  reset() {
+    this.signals$ = new Subject<any>();
+    this.signalsCount$ = this.signals$.pipe(
+      scan((acc) => acc + 1, 0),
+      startWith(0)
+    );
   }
 }

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -5,7 +5,7 @@ import {
   OnDestroy,
   OnInit,
   TemplateRef,
-  ViewContainerRef
+  ViewContainerRef,
 } from '@angular/core';
 
 import {
@@ -14,16 +14,16 @@ import {
   ObservableInput,
   Observer,
   Unsubscribable,
-  Subscription
+  Subscription,
 } from 'rxjs';
 import { createRenderAware, RenderAware, StrategySelection } from '../core';
 import {
   createTemplateManager,
-  TemplateManager
+  TemplateManager,
 } from '../core/utils/template-manager_creator';
 import {
   DEFAULT_STRATEGY_NAME,
-  getStrategies
+  getStrategies,
 } from '../render-strategies/strategies/strategies-map';
 
 export interface LetViewContext<T> {
@@ -124,7 +124,7 @@ export interface LetViewContext<T> {
  */
 @Directive({
   selector: '[rxLet]',
-  exportAs: 'renderNotifier'
+  exportAs: 'renderNotifier',
 })
 export class LetDirective<U> implements OnInit, OnDestroy {
   static ngTemplateGuard_rxLet: 'binding';
@@ -166,20 +166,21 @@ export class LetDirective<U> implements OnInit, OnDestroy {
   >;
   private readonly resetObserver: NextObserver<void> = {
     next: () => {
+      this.templateManager.insertEmbeddedView('rxSuspense');
       this.templateManager.updateViewContext({
         $implicit: undefined,
         rxLet: undefined,
         $error: false,
-        $complete: false
+        $complete: false,
       });
-    }
+    },
   };
   private readonly updateObserver: Observer<U | null | undefined> = {
     next: (value: U | null | undefined) => {
       this.templateManager.insertEmbeddedView('rxNext');
       this.templateManager.updateViewContext({
         $implicit: value,
-        rxLet: value
+        rxLet: value,
       });
     },
     error: (error: Error) => {
@@ -187,7 +188,7 @@ export class LetDirective<U> implements OnInit, OnDestroy {
       this.templateManager.insertEmbeddedView('rxNext');
       this.templateManager.insertEmbeddedView('rxError');
       this.templateManager.updateViewContext({
-        $error: true
+        $error: true,
       });
     },
     complete: () => {
@@ -195,9 +196,9 @@ export class LetDirective<U> implements OnInit, OnDestroy {
       this.templateManager.insertEmbeddedView('rxNext');
       this.templateManager.insertEmbeddedView('rxComplete');
       this.templateManager.updateViewContext({
-        $complete: true
+        $complete: true,
       });
-    }
+    },
   };
 
   static ngTemplateContextGuard<U>(
@@ -217,13 +218,13 @@ export class LetDirective<U> implements OnInit, OnDestroy {
       $implicit: undefined,
       rxLet: undefined,
       $error: false,
-      $complete: false
+      $complete: false,
     });
 
     this.renderAware = createRenderAware({
       strategies: this.strategies,
       resetObserver: this.resetObserver,
-      updateObserver: this.updateObserver
+      updateObserver: this.updateObserver,
     });
     this.renderAware.nextStrategy(DEFAULT_STRATEGY_NAME);
   }

--- a/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
@@ -4,7 +4,7 @@ import { priorityTickMap } from '../rxjs/scheduling/priority-tick-map';
 import { map, switchMap, tap } from 'rxjs/operators';
 import {
   RenderStrategy,
-  RenderStrategyFactoryConfig
+  RenderStrategyFactoryConfig,
 } from '../../core/render-aware';
 import { coalesceWith } from '../rxjs/operators/coalesceWith';
 import { promiseTick } from '../rxjs/scheduling/promiseTick';
@@ -34,7 +34,7 @@ export function getLocalStrategies<T>(
 ): { [strategy: string]: RenderStrategy } {
   return {
     local: createLocalStrategy<T>(config),
-    detach: createDetachStrategy(config)
+    detach: createDetachStrategy(config),
   };
 }
 
@@ -73,12 +73,12 @@ export function createLocalStrategy<T>(
   const tick = priorityTickMap[priority];
 
   const renderMethod = () => {
-    detectChanges(component);
+    config.cdRef.detectChanges();
   };
-  const behavior = o =>
+  const behavior = (o) =>
     o.pipe(
       coalesceWith(promiseDurationSelector, component),
-      switchMap(v => tick.pipe(map(() => v))),
+      switchMap((v) => tick.pipe(map(() => v))),
       tap(renderMethod)
     );
   const scheduleCD = () =>
@@ -88,7 +88,7 @@ export function createLocalStrategy<T>(
     name: 'local',
     detectChanges: renderMethod,
     rxScheduleCD: behavior,
-    scheduleCD
+    scheduleCD,
   };
 }
 
@@ -131,10 +131,10 @@ export function createDetachStrategy(
     detectChanges(component);
     config.cdRef.detach();
   };
-  const behavior = o =>
+  const behavior = (o) =>
     o.pipe(
       coalesceWith(promiseDurationSelector, component),
-      switchMap(v => tick.pipe(map(() => v))),
+      switchMap((v) => tick.pipe(map(() => v))),
       tap(renderMethod)
     );
   const scheduleCD = () =>
@@ -144,6 +144,6 @@ export function createDetachStrategy(
     name: 'detach',
     detectChanges: renderMethod,
     rxScheduleCD: behavior,
-    scheduleCD
+    scheduleCD,
   };
 }


### PR DESCRIPTION
This PR solves adds several things and solves small issues:
- adds `error` and `complete` observable notification handling for `LetDirective` via a custom operator
- embeds `rxSuspense` template to the view on reset of the bound observable
- invokes `detechChanges()` for `LocalStrategy` differently (with no worries that `ChangeDetectionRef` instance will drop component's reference)
- adds "reset" button to the `template-demo` page with template binding example