### PR TITLE
State docs fixes

### DIFF
--- a/apps/state-demo/src/app/examples/demo-basics/Readme.md
+++ b/apps/state-demo/src/app/examples/demo-basics/Readme.md
@@ -23,5 +23,5 @@ Furthermore, there is a refresh button. A click on it also refreshes the list da
 
 Chapters we will discuss are:
 
-- [Setup a reactive state, selections and, UI interactions](./1)
-- [Handing Side Effects reactively](./2)
+- [Setup a reactive state, selections and, UI interactions](https://github.com/BioPhoton/rx-angular/tree/master/apps/state-demo/src/app/examples/demo-basics/1)
+- [Handing Side Effects reactively](https://github.com/BioPhoton/rx-angular/tree/master/apps/state-demo/src/app/examples/demo-basics/2)

--- a/libs/state/README.md
+++ b/libs/state/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fstate.svg)](https://www.npmjs.com/package/%40rx-angular%2Fstate)
 ![rx-angular CI](https://github.com/BioPhoton/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=master)
-[![Coverage Status](https://github.com/BioPhoton/rx-angular/blob/github-pages/docs/test-coverage/state/jest-coverage-badge.svg)](https://biophoton.github.io/rx-angular/test-coverage/state/lcov-report/index.html)
+[![Coverage Status](https://raw.githubusercontent.com/BioPhoton/rx-angular/github-pages/docs/test-coverage/state/jest-coverage-badge.svg)](https://biophoton.github.io/rx-angular/test-coverage/state/lcov-report/index.html)
 
 ## Reactive Component State for Angular
 

--- a/libs/state/docs/api/rx-state.md
+++ b/libs/state/docs/api/rx-state.md
@@ -47,7 +47,7 @@ class RxState<T extends object> implements OnDestroy, Subscribable<T> {
 
 ![](https://raw.githubusercontent.com/BioPhoton/rx-angular/master/libs/state/images/api-reveal.jpg)
 
-## \$
+## \$ (state observable)
 
 ##### typeof: Observable&#60;T&#62;
 

--- a/libs/state/docs/api/rx-state.md
+++ b/libs/state/docs/api/rx-state.md
@@ -43,9 +43,9 @@ class RxState<T extends object> implements OnDestroy, Subscribable<T> {
 }
 ```
 
-![](../../images/api-schema.jpg)
+![](https://raw.githubusercontent.com/BioPhoton/rx-angular/master/libs/state/images/api-schema.jpg)
 
-![](../../images/api-reveal.jpg)
+![](https://raw.githubusercontent.com/BioPhoton/rx-angular/master/libs/state/images/api-reveal.jpg)
 
 ## \$
 

--- a/libs/state/docs/snippets/selecting-the-viewmodel.md
+++ b/libs/state/docs/snippets/selecting-the-viewmodel.md
@@ -45,7 +45,7 @@ As your view requires additional and/or derived information from your component 
 Changes of your `viewModel$` ultimately result in component renderings, so we have to make sure that it's emissions
 are distinct.
 
-## Using [`selectSlice`](../api/operators/select-slice.md):
+## Using [`selectSlice`](https://github.com/BioPhoton/rx-angular/blob/master/libs/state/docs/api/operators/select-slice.md):
 
 For this scenario we created the `selectSlice` operator.
 It returns an Observable that emits a distinct subset of the received object.
@@ -72,7 +72,7 @@ export class ViewModelComponent extends RxState<ComponentState> {
 }
 ```
 
-## Multiple Observables and [`selectSlice`](../api/operators/select-slice.md):
+## Multiple Observables and [`selectSlice`](https://github.com/BioPhoton/rx-angular/blob/master/libs/state/docs/api/operators/select-slice.md):
 
 There are situations where you want to divide your `ViewModel` into different parts.
 

--- a/libs/template/README.md
+++ b/libs/template/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Ftemplate.svg)](https://www.npmjs.com/package/%40rx-angular%2Ftemplate)
 ![rx-angular CI](https://github.com/BioPhoton/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=master)
-[![Coverage Status](https://github.com/BioPhoton/rx-angular/blob/github-pages/docs/test-coverage/template/jest-coverage-badge.svg)](https://biophoton.github.io/rx-angular/test-coverage/template/lcov-report/index.html)
+[![Coverage Status](https://raw.githubusercontent.com/BioPhoton/rx-angular/github-pages/docs/test-coverage/template/jest-coverage-badge.svg)](https://biophoton.github.io/rx-angular/test-coverage/template/lcov-report/index.html)
 
 ## Reactive Template Rendering for Angular
 


### PR DESCRIPTION
### What Problem/Issue is it trying to solve?

Fixes in GitHub `.md` files for upcoming web docs.

### Change List

- Relative links for images replaced with https://raw.githubusercontent.com/.
- ⚠️ Coverage badges links also changed to raw file links.
- Relative links in the state docs replaced with global links.
- $ heading in `rx-state.md` changed to $ (state observable). Otherwise, it's not working as anchor link :)