### PR TITLE
Updating testing scenarios and adding tests for TemplateManager (and more)

### DIFF
--- a/libs/template/src/lib/core/utils/coalescing-manager.ts
+++ b/libs/template/src/lib/core/utils/coalescing-manager.ts
@@ -1,4 +1,4 @@
-import { createPropertiesWeakMap } from './index';
+import { createPropertiesWeakMap } from './properties-weakmap';
 
 interface CoalescingContextProps {
   numCoalescingSubscribers: number;

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -169,9 +169,7 @@ export class LetDirective<U> implements OnInit, OnDestroy {
   >;
   private readonly resetObserver: NextObserver<void> = {
     next: () => {
-      this.templateManager.hasTemplateRef('rxSuspense')
-        ? this.templateManager.displayView('rxSuspense')
-        : this.templateManager.displayView('rxNext');
+      this.displayInitialView();
       this.templateManager.updateViewContext({
         $implicit: undefined,
         rxLet: undefined,
@@ -238,15 +236,19 @@ export class LetDirective<U> implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.templateManager.addTemplateRef('rxNext', this.nextTemplateRef);
-    // @TODO comment why we do this here
-    this.templateManager.hasTemplateRef('rxSuspense')
-      ? this.templateManager.displayView('rxSuspense')
-      : this.templateManager.displayView('rxNext');
+    this.displayInitialView();
     this.subscription = this.renderAware.subscribe();
   }
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
     this.templateManager.destroy();
+  }
+
+  private displayInitialView = () => {
+    // display "suspense" template if provided, display "next" otherwise
+    this.templateManager.hasTemplateRef('rxSuspense')
+      ? this.templateManager.displayView('rxSuspense')
+      : this.templateManager.displayView('rxNext');
   }
 }


### PR DESCRIPTION
This PR touches on a few things that came up during https://github.com/BioPhoton/rx-angular/pull/222. Each of those things (and some additional ones) will be explained in a separate paragraph with proposals on how to resolve those.

## TODO for me
There was a TODO comment for me to add a comment on an implementation detail explaining why there is a condition on displaying "suspense" or "next" in the `LetDirective`. I added those and also refactored this part of a code for further clarity.

## Template-binding example is broken
Latest commits broke template-binding example in `template-demo` app. Considering this as a primary example with one of the most basic and simplest use-cases for the `LetDirective`, this got my attention. Solution was rather simple: inside `TemplateManager`'s implementation there were two lines of code:
```ts
viewContainerRef.detach(0);
...
viewContainerRef.insert(viewCache.get(name), 0);
```
For the functionality to work again, the argument of `index` of the view to be detached/inserted needed to be dropped:
```ts
viewContainerRef.detach();
...
viewContainerRef.insert(viewCache.get(name));
```
This works because the view we want to detach or insert is **the latest** one, and `ViewContainerRef#detach` and `ViewContainerRef#insert` work on the latest view if no `index` value is provided. The `index` of the latest view is not always `0` and that seems to be an implementation detail on the Angular core's side.

I added the above change and also added some test for the `TemplateManager` for that.

## jsdoc for `TemplateManager`
I moved jsdoc for `TemplateManager` inside an interface. Please notice that earlier, when jsdoc was attached to the object returned by `createTemplateManager` factory function, the jsdoc was not displayed in the IDE. Moving it to the interface solved the issue.

## Naming convention for TypeScript generics
I made a bold move of renaming generics for `TemplateManager`- from `ViewContext` to `C` and `Names` to `N`. I believe this is THE convention of naming generics in TypeScript that the core team had in mind. Please notice, that `ViewContext` as a generic is easily mistaken for a concrete type when used within the implementation code. I think we should name them distinctively, to know instantly that we are dealing with generics, not a concrete type (given, they also have their limitations in TypeScript).

## Animation example within `experiments`
I played with the demo for animations and it seems to be working after my change. Please try it out and let me know if there's something I missed.

## Import for `coalescing-manager.ts `
I noticed that during compilation there are warnings about circular dependency within a project. I fixed it by updating import statement for the coalescing manager.

## Testing module for `TemplateManager`
I updated a testing module under test for `template-manager_creator.spec.ts `. With my changes we are able to determine which template is currently inserted to the view container based on its text content. Also, with it we are able to test `TemplateManager#updateViewContext` method, which wasn't possible before.

## Exposing internals of `TemplateManager` implementation
I strongly believe that exposing internals of `TemplateManager` implementation, like template and view cache or a `ViewContainerRef` instance only for testing purposes should be avoided as much as possible. Just like the comment I found inside of `createTemplateManager` factory said - we should rethink that. I removed exposed properties and proposed some changes to existing tests for `TemplateManager`. I extended testing module to be more flexible (like I described in the previous paragraph) and tried to refactor tests so that they would match the experience and use-cases of the `TemplateManager`'s user. 