### PR TITLE
fix(template): fix let directive initial view

### DIFF
--- a/libs/template/spec/let/let.directive.next.spec.ts
+++ b/libs/template/spec/let/let.directive.next.spec.ts
@@ -57,10 +57,10 @@ describe('LetDirective when nexting values', () => {
     expect(componentNativeElement).toBeDefined();
   });
 
-  it('should render undefined as value when initially undefined was passed (as no value ever was emitted)', () => {
+  it('should render nothing when initially undefined was passed (as no value ever was emitted)', () => {
     letDirectiveTestComponent.value$ = undefined;
     fixtureLetDirectiveTestComponent.detectChanges();
-    expect(componentNativeElement.textContent).toBe('undefined');
+    expect(componentNativeElement.textContent).toBe('');
   });
 
   it('should render null as value when initially null was passed (as no value ever was emitted)', () => {
@@ -90,7 +90,7 @@ describe('LetDirective when nexting values', () => {
   it('should render nothing as value when initially NEVER was passed (as no value ever was emitted)', () => {
     letDirectiveTestComponent.value$ = NEVER;
     fixtureLetDirectiveTestComponent.detectChanges();
-    expect(componentNativeElement.textContent).toBe('undefined');
+    expect(componentNativeElement.textContent).toBe('');
   });
 
   it('should render emitted value from passed observable without changing it', () => {
@@ -126,7 +126,7 @@ describe('LetDirective when nexting values', () => {
   it('should render values over time when a new observable was passed', fakeAsync(() => {
     letDirectiveTestComponent.value$ = interval(1000).pipe(take(3));
     fixtureLetDirectiveTestComponent.detectChanges();
-    expect(componentNativeElement.textContent).toBe('undefined');
+    expect(componentNativeElement.textContent).toBe('');
     tick(1000);
     fixtureLetDirectiveTestComponent.detectChanges();
     expect(componentNativeElement.textContent).toBe('0');

--- a/libs/template/spec/let/let.directive.template-binding.no-suspense.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.no-suspense.spec.ts
@@ -52,7 +52,7 @@ describe('LetDirective when template binding without "suspense" template', () =>
   it('should not render anything when "suspense" template is not provided until a value is emitted', () => {
     component.value$ = new Subject();
     fixture.detectChanges();
-    expectContentToBe('undefined');
+    expectContentToBe('');
 
     (component.value$ as Subject<number>).next(1);
     fixture.detectChanges();

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -246,9 +246,9 @@ export class LetDirective<U> implements OnInit, OnDestroy {
   }
 
   private displayInitialView = () => {
-    // display "suspense" template if provided, display "next" otherwise
-    this.templateManager.hasTemplateRef('rxSuspense')
-      ? this.templateManager.displayView('rxSuspense')
-      : this.templateManager.displayView('rxNext');
+    // display "suspense" template if provided
+    if (this.templateManager.hasTemplateRef('rxSuspense')) {
+      this.templateManager.displayView('rxSuspense');
+    }
   }
 }


### PR DESCRIPTION
### Description

The let directive currently calls `this.templateManager.displayView('rxNext');` in the `ngOnInit` method when no `rxSuspense` template was found. This is not only an issue as this is against the idea of "lazy rendering". 
If your value you bound to the `LetDirective` does not emit any value until the `LetDirective` renders it's initial view, you will end up in runtime errors since all your ViewBindings are now bound to an undefined object.
Also, in my opinion the `LetDirective` should really not render _ANYTHING_ until the first "defined" ( !== undefined ) value appears.  Of course only if you haven't provided a `rxSuspense` template.

### Steps to reproduce

* revert changes in `let.directive.ts`
* `yarn nx s tour-of-heroes`
* navigate to a detail-view from the dashboard
* you will get an `core.js:4196 ERROR TypeError: Cannot read property 'name' of undefined` error

![image](https://user-images.githubusercontent.com/4904455/90988625-8b1bd900-e594-11ea-9275-0acf1e2b75c4.png)
