### PR TITLE
chore: force push on docs generation action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: EndBug/add-and-commit@v4 # You can change this to use a specific version
         with:
           add: 'docs/*'
+          force: true
           author_name: Github Action
           message: 'chore(docs): GitHub pages generation'
           # Whether to use the --force option on `git add`, in order to bypass eventual gitignores


### PR DESCRIPTION
currently docs are not generated correctly via github actions. With `force: true` it should work correctly
