### PR TITLE
docs(state): fix wrong property name

### DIFF
--- a/libs/state/docs/api/transformation-helpers/array/update.md
+++ b/libs/state/docs/api/transformation-helpers/array/update.md
@@ -73,7 +73,7 @@ export class ListComponent {
       'creatures',
       this.updateCreature$,
       ({ creatures }, creatureToUpdate) => {
-        return update(creatures, creatureToRemove, (a, b) => a.id === b.id);
+        return update(creatures, creatureToUpdate, (a, b) => a.id === b.id);
       }
     );
   }


### PR DESCRIPTION
Just a very minor fix in the docs – the name of the property should be `creatureToUpdate` instead of `creatureToRemove`.