### PR TITLE
fix(strategies): complete API docs

### DIFF
--- a/libs/template/src/lib/render-strategies/strategies/global.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/global.strategy.ts
@@ -21,29 +21,12 @@ export function getGlobalStrategies(
  * This strategy leverages Angular's internal `ɵmarkDirty` render method.
  * This means it acts identical to `ChangeDetectorRef#markForCheck` but works also zone-less.
  *
- * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling |
- * | --------- | --------------| --------------- | ------------- | ---------- |
- * | `global`  | ✔             | `ɵmarkDirty`    | ❌            | ❌         |
+ * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling |
+ * | --------- | --------------| ----------------- | ------------- | ---------- |
+ * | `global`  | ✔             | ⮁ `ɵmarkDirty`   | ❌            | ❌         |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return { RenderStrategy } - The calculated strategy
- *
- */
-
-/**
- *
- * Global Strategy
- *
- * This strategy is rendering the application root and
- * all it's children that are on a path
- * that is marked as dirty or has components with `ChangeDetectionStrategy.Default`.
- *
- * | Name        | ZoneLess | Render Method | ScopedCoalescing | Scheduling | Chunked |
- * |-------------| ---------| --------------| ---------------- | ---------- |-------- |
- * | `global`     | ✔        | ɵMD           | C + Pr          | ❌         | ❌      |
- *
- * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
- * @return {RenderStrategy<T>} - The calculated strategy
  *
  */
 export function createGlobalStrategy(

--- a/libs/template/src/lib/render-strategies/strategies/global.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/global.strategy.ts
@@ -13,14 +13,20 @@ export function getGlobalStrategies(
 }
 
 /**
+ *
+ * @description
+ *
  * Global Strategies
  *
- * - ɵMD - `ɵmarkDirty`
- * - C - `Component`
+ * This strategy leverages Angular's internal `ɵmarkDirty` render method.
+ * This means it acts identical to `ChangeDetectorRef#markForCheck` but works also zone-less.
  *
- * | Name        | ZoneLess | Render Method | ScopedCoalescing | Scheduling | Chunked |
- * |-------------| ---------| --------------| ---------------- | ---------- |-------- |
- * | `global`     | ✔        | ɵMD           | C + Pr          | ❌         | ❌      |
+ * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling |
+ * | --------- | --------------| --------------- | ------------- | ---------- |
+ * | `global`  | ✔             | `ɵmarkDirty`    | ❌            | ❌         |
+ *
+ * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
+ * @return { RenderStrategy } - The calculated strategy
  *
  */
 

--- a/libs/template/src/lib/render-strategies/strategies/global.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/global.strategy.ts
@@ -18,12 +18,13 @@ export function getGlobalStrategies(
  *
  * Global Strategies
  *
- * This strategy leverages Angular's internal `ɵmarkDirty` render method.
- * This means it acts identical to `ChangeDetectorRef#markForCheck` but works also zone-less.
+ * This strategy leverages Angular's internal [`ɵmarkDirty`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/instructions/change_detection.ts#L36) render method.
+ * It acts identical to [`ChangeDetectorRef#markForCheck`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/view_ref.ts#L128) but works also zone-less.
+ * `markDirty` in comparison to `markForCheck` also calls [`scheduleTick`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/instructions/shared.ts#L1863) which is the reason why it also works in zone-less environments.
  *
- * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling |
- * | --------- | --------------| ----------------- | ------------- | ---------- |
- * | `global`  | ✔             | ⮁ `ɵmarkDirty`   | ❌            | ❌         |
+ * | Name      | Zone Agnostic | Render Method     | Coalescing      | Scheduling       |
+ * | --------- | --------------| ----------------- | --------------- | ---------------- |
+ * | `global`  | ✔             | ⮁ `ɵmarkDirty`   | ✔ `RootContext` | [`animationFrame`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/util/misc_utils.ts#L39)   |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return { RenderStrategy } - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
@@ -39,7 +39,9 @@ export function getLocalStrategies<T>(
 }
 
 /**
- *  Local Strategy
+ * @description
+ *
+ * Local Strategy
  *
  * This strategy is rendering the actual component and
  * all it's children that are on a path
@@ -57,9 +59,9 @@ export function getLocalStrategies<T>(
  * 'Scoped' coalescing, in addition, means **grouping the collected events** by a specific context.
  * E. g. the **component** from which the re-rendering was initiated.
  *
- * | Name        | Also ZoneLess | Render Method | ScopedCoalescing | Scheduling     |
- * |-------------| --------------| --------------| ---------------- | -------------- |
- * | `local`     | ✔             | detectChanges | ✔                | animationFrame |
+ * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling                 |
+ * | --------- | --------------| --------------- | ------------- | -------------------------- |
+ * | `local`   | ✔             | `detectChanges` | ✔             | `requestAnimationFrame`   |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
@@ -54,12 +54,12 @@ export function getLocalStrategies<T>(
  * [EventLoop](https://developer.mozilla.org/de/docs/Web/JavaScript/EventLoop) tick, that would cause a re-render and
  * execute **re-rendering only once**.
  *
- * 'Scoped' coalescing, in addition, means **grouping the collected events by** a specific context.
+ * 'Scoped' coalescing, in addition, means **grouping the collected events** by a specific context.
  * E. g. the **component** from which the re-rendering was initiated.
  *
- * | Name        | ZoneLess | Render Method | ScopedCoalescing | Scheduling | Chunked |
- * |-------------| ---------| --------------| ---------------- | ---------- |-------- |
- * | `local`     | ✔        | ɵDC           | C + Pr           | aF         | ❌      |
+ * | Name        | Also ZoneLess | Render Method | ScopedCoalescing | Scheduling     |
+ * |-------------| --------------| --------------| ---------------- | -------------- |
+ * | `local`     | ✔             | detectChanges | ✔                | animationFrame |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
@@ -48,7 +48,7 @@ export function getLocalStrategies<T>(
  * that is marked as dirty or has components with `ChangeDetectionStrategy.Default`.
  *
  * As detectChanges has no coalescing of render calls
- * like `ChangeDetectorRef#markForCheck` or `ɵmarkDirty` has, so we have to apply our own coalescing, 'scoped' on
+ * like [`ChangeDetectorRef#markForCheck`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/view_ref.ts#L128) or [`ɵmarkDirty`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/instructions/change_detection.ts#L36) has, so we have to apply our own coalescing, 'scoped' on
  * component level.
  *
  * Coalescing, in this very manner,
@@ -59,9 +59,12 @@ export function getLocalStrategies<T>(
  * 'Scoped' coalescing, in addition, means **grouping the collected events** by a specific context.
  * E. g. the **component** from which the re-rendering was initiated.
  *
- * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling                 |
- * | --------- | --------------| ----------------- | ------------- | -------------------------- |
- * | `local`   | ✔             | 🠗 `detectChanges` | ✔             | `requestAnimationFrame`   |
+ * This context could be the Component instance or a ViewContextRef,
+ * both accessed over the context over `ChangeDetectorRef#context`.
+ *
+ * | Name      | Zone Agnostic | Render Method     | Coalescing         | Scheduling                 |
+ * | --------- | --------------| ----------------- | ------------------ | -------------------------- |
+ * | `local`   | ✔             | 🠗 `detectChanges` | ✔ ComponentContext | `requestAnimationFrame`   |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/local.strategy.ts
@@ -59,9 +59,9 @@ export function getLocalStrategies<T>(
  * 'Scoped' coalescing, in addition, means **grouping the collected events** by a specific context.
  * E. g. the **component** from which the re-rendering was initiated.
  *
- * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling                 |
- * | --------- | --------------| --------------- | ------------- | -------------------------- |
- * | `local`   | ✔             | `detectChanges` | ✔             | `requestAnimationFrame`   |
+ * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling                 |
+ * | --------- | --------------| ----------------- | ------------- | -------------------------- |
+ * | `local`   | ✔             | 🠗 `detectChanges` | ✔             | `requestAnimationFrame`   |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/native.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/native.strategy.ts
@@ -12,9 +12,9 @@ import { ɵmarkDirty as markDirty } from '@angular/core';
  * This strategy mirrors Angular's built-in `async` pipe.
  * This means for every emitted value `ChangeDetectorRef#markForCheck` is called.
  *
- * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling |
- * | --------- | --------------| --------------- | ------------- | ---------- |
- * | `native`  | ❌             | `markForCheck` | ❌             | ❌         |
+ * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling |
+ * | --------- | --------------| ----------------- | ------------- | ---------- |
+ * | `native`  | ❌             | ⮁ `markForCheck` | ❌             | ❌         |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/native.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/native.strategy.ts
@@ -3,17 +3,18 @@ import { tap } from 'rxjs/operators';
 import { ɵmarkDirty as markDirty } from '@angular/core';
 
 /**
- * Native Strategy
  * @description
  *
- * - mFC - `cdRef.markForCheck`
+ * Native Strategy
+ *
+ * @description
  *
  * This strategy mirrors Angular's built-in `async` pipe.
  * This means for every emitted value `ChangeDetectorRef#markForCheck` is called.
  *
- * | Name        | ZoneLess | Render Method | ScopedCoalescing | Scheduling | Chunked |
- * |-------------| ---------| --------------| ---------------- | ---------- |-------- |
- * | `native`    | ❌       | mFC           | ❌                | ❌         | ❌      |
+ * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling |
+ * | --------- | --------------| --------------- | ------------- | ---------- |
+ * | `native`  | ❌             | `markForCheck` | ❌             | ❌         |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/native.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/native.strategy.ts
@@ -14,9 +14,9 @@ import { ɵmarkDirty as markDirty } from '@angular/core';
  * Angular still needs zone.js to trigger the [`ApplicationRef#tick`](https://github.com/angular/angular/blob/7d8dce11c0726cdba999fc59a83295d19e5e92e6/packages/core/src/application_ref.ts#L719) to re-render,
  * as the internally called function [`markViewDirty`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/instructions/shared.ts#L1837) is only responsible for dirty marking and not rendering.
  *
- * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling |
- * | --------- | --------------| ----------------- | ------------- | ---------- |
- * | `native`  | ❌             | ⮁ `markForCheck` | ❌             | ❌         |
+ * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling               |
+ * | --------- | --------------| ----------------- | ------------- | ------------------------ |
+ * | `native`  | ❌            | ⮁ `markForCheck` | ✔ RootContext  | `requestAnimationFrame`  |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/native.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/native.strategy.ts
@@ -10,7 +10,9 @@ import { ɵmarkDirty as markDirty } from '@angular/core';
  * @description
  *
  * This strategy mirrors Angular's built-in `async` pipe.
- * This means for every emitted value `ChangeDetectorRef#markForCheck` is called.
+ * This means for every emitted value [`ChangeDetectorRef#markForCheck`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/view_ref.ts#L128) is called.
+ * Angular still needs zone.js to trigger the [`ApplicationRef#tick`](https://github.com/angular/angular/blob/7d8dce11c0726cdba999fc59a83295d19e5e92e6/packages/core/src/application_ref.ts#L719) to re-render,
+ * as the internally called function [`markViewDirty`](https://github.com/angular/angular/blob/930eeaf177a4c277f437f42314605ff8dc56fc82/packages/core/src/render3/instructions/shared.ts#L1837) is only responsible for dirty marking and not rendering.
  *
  * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling |
  * | --------- | --------------| ----------------- | ------------- | ---------- |

--- a/libs/template/src/lib/render-strategies/strategies/noop.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/noop.strategy.ts
@@ -4,13 +4,16 @@ import {
 } from '../../core/render-aware/interfaces';
 
 /**
+ * @description
+ *
  * Noop Strategy
  *
- * This strategy is does nothing. It serves for debugging only
+ * This strategy is does nothing. It serves several performance features
+ * as well as a helpful tool when migrating and for debugging.
  *
- * | Name        | ZoneLess | Render Method | ScopedCoalescing | Scheduling | Chunked |
- * |-------------| ---------| --------------| ---------------- | ---------- |-------- |
- * | `noop`      | ❌       | ❌             | ❌                | ❌         | ❌      |
+ * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling |
+ * | --------- | --------------| --------------- | ------------- | ---------- |
+ * | `noop`    | ✔             |❌               | ❌             | ❌         |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/noop.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/noop.strategy.ts
@@ -8,12 +8,13 @@ import {
  *
  * Noop Strategy
  *
- * This strategy is does nothing. It serves several performance features
- * as well as a helpful tool when migrating and for debugging.
+ * The no-operation strategy does nothing.
+ * It can be a useful tool for performance improvements as well as debugging
+ * The [`[viewport-prio]`](https://github.com/BioPhoton/rx-angular/blob/ef99804c1b07aeb96763cacca6afad7bbdab03b1/libs/template/src/lib/experimental/viewport-prio/viewport-prio.directive.ts) directive use it to limit renderings to only visible components:
  *
  * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling |
  * | --------- | --------------| ----------------- | ------------- | ---------- |
- * | `noop`    | ✔             | - ❌              | ❌             | ❌         |
+ * | `noop`    | ✔             | - `noop`          | ❌             | ❌         |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/noop.strategy.ts
+++ b/libs/template/src/lib/render-strategies/strategies/noop.strategy.ts
@@ -11,9 +11,9 @@ import {
  * This strategy is does nothing. It serves several performance features
  * as well as a helpful tool when migrating and for debugging.
  *
- * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling |
- * | --------- | --------------| --------------- | ------------- | ---------- |
- * | `noop`    | ✔             |❌               | ❌             | ❌         |
+ * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling |
+ * | --------- | --------------| ----------------- | ------------- | ---------- |
+ * | `noop`    | ✔             | - ❌              | ❌             | ❌         |
  *
  * @param config { RenderStrategyFactoryConfig } - The values this strategy needs to get calculated.
  * @return {RenderStrategy} - The calculated strategy

--- a/libs/template/src/lib/render-strategies/strategies/strategies-map.ts
+++ b/libs/template/src/lib/render-strategies/strategies/strategies-map.ts
@@ -15,13 +15,13 @@ export const DEFAULT_STRATEGY_NAME = 'local';
  *
  * Built-in Strategies:
  *
- * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling                 |
- * | --------- | --------------| ----------------- | ------------- | -------------------------- |
- * | `local`   | ✔             | 🠗 `detectChanges` | ✔             | `requestAnimationFrame`   |
- * | `global`  | ✔             | ⮁ `ɵmarkDirty`    | ❌             | ❌                        |
- * | `detach`  | ✔             | ⭭ `detectChanges` | ✔             | `requestAnimationFrame`   |
- * | `noop`    | ✔             | - ❌              | ❌             | ❌                        |
- * | `native`  | ❌             | ⮁ `markForCheck` | ❌             | ❌                        |
+ * | Name      | Zone Agnostic | Render Method     | Coalescing         | Scheduling                 |
+ * | --------- | --------------| ----------------- | ------------------ | -------------------------- |
+ * | `local`   | ✔             | 🠗 `detectChanges` | ✔ ComponentContext | `requestAnimationFrame`   |
+ * | `global`  | ✔             | ⮁ `ɵmarkDirty`    | ✔ RootContext     | `requestAnimationFrame`   |
+ * | `detach`  | ✔             | ⭭ `detectChanges` | ✔ ComponentContext | `requestAnimationFrame`   |
+ * | `noop`    | ✔             | - `noop`          | ❌                 | ❌                        |
+ * | `native`  | ❌             | ⮁ `markForCheck` | ✔ RootContext     | `requestAnimationFrame`  |
  *
  * @param config
  */

--- a/libs/template/src/lib/render-strategies/strategies/strategies-map.ts
+++ b/libs/template/src/lib/render-strategies/strategies/strategies-map.ts
@@ -9,6 +9,22 @@ import { getGlobalStrategies } from './global.strategy';
 
 export const DEFAULT_STRATEGY_NAME = 'local';
 
+/**
+ * @description
+ * This method returns the provided strategies as name:strategy pair
+ *
+ * Built-in Strategies:
+ *
+ * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling                 |
+ * | --------- | --------------| --------------- | ------------- | -------------------------- |
+ * | `local`   | ✔             | `detectChanges` | ✔             | `requestAnimationFrame`   |
+ * | `global`  | ✔             | `ɵmarkDirty`    | ❌             | ❌                        |
+ * | `detach`  | ✔             | `detectChanges` | ✔             | `requestAnimationFrame`   |
+ * | `noop`    | ✔             | ❌              | ❌             | ❌                        |
+ * | `native`  | ❌             | `markForCheck` | ❌             | ❌                        |
+ *
+ * @param config
+ */
 export function getStrategies(
   config: RenderStrategyFactoryConfig
 ): { [strategy: string]: RenderStrategy } {
@@ -19,25 +35,3 @@ export function getStrategies(
     ...getLocalStrategies(config),
   };
 }
-
-/**
- * Strategies
- *
- * - mFC - `cdRef.markForCheck`
- * - dC - `cdRef.detectChanges`
- * - ɵMD - `ɵmarkDirty`
- * - ɵDC - `ɵdetectChanges`
- * - C - `Component`
- * - det - `cdRef.detach`
- * - ret - `cdRef.reattach`
- * - Pr - `Promise`
- * - aF - `requestAnimationFrame`
- *
- * | Name        | ZoneLess | Render Method | ScopedCoalescing | Scheduling | Chunked |
- * |-------------| ---------| --------------| ---------------- | ---------- |-------- |
- * | `noop`      | ❌       | ❌             | ❌               | ❌         | ❌       |
- * | `native`    | ❌       | mFC           | ❌                | ❌         | ❌      |
- * | `global`    | ✔        | ɵMD           | C + Pr           | ❌         | ❌      |
- * | `local`     | ✔        | ɵDC           | C + Pr           | aF         | ❌      |
- * | `detach`    | ✔ ️     | ret,ɵDC, det  | C + Pr           | aF         | ❌      |
- */

--- a/libs/template/src/lib/render-strategies/strategies/strategies-map.ts
+++ b/libs/template/src/lib/render-strategies/strategies/strategies-map.ts
@@ -15,13 +15,13 @@ export const DEFAULT_STRATEGY_NAME = 'local';
  *
  * Built-in Strategies:
  *
- * | Name      | Zone Agnostic | Render Method   | Coalescing    | Scheduling                 |
- * | --------- | --------------| --------------- | ------------- | -------------------------- |
- * | `local`   | ✔             | `detectChanges` | ✔             | `requestAnimationFrame`   |
- * | `global`  | ✔             | `ɵmarkDirty`    | ❌             | ❌                        |
- * | `detach`  | ✔             | `detectChanges` | ✔             | `requestAnimationFrame`   |
- * | `noop`    | ✔             | ❌              | ❌             | ❌                        |
- * | `native`  | ❌             | `markForCheck` | ❌             | ❌                        |
+ * | Name      | Zone Agnostic | Render Method     | Coalescing    | Scheduling                 |
+ * | --------- | --------------| ----------------- | ------------- | -------------------------- |
+ * | `local`   | ✔             | 🠗 `detectChanges` | ✔             | `requestAnimationFrame`   |
+ * | `global`  | ✔             | ⮁ `ɵmarkDirty`    | ❌             | ❌                        |
+ * | `detach`  | ✔             | ⭭ `detectChanges` | ✔             | `requestAnimationFrame`   |
+ * | `noop`    | ✔             | - ❌              | ❌             | ❌                        |
+ * | `native`  | ❌             | ⮁ `markForCheck` | ❌             | ❌                        |
  *
  * @param config
  */


### PR DESCRIPTION
This PR aims to clearly document the following strategies and their tables:
- noop
- native
- global
- local

The tables now have the following columns:
 | Name      | Zone Agnostic | Render Method     | Coalescing         | Scheduling                 |
 | --------- | --------------| ----------------- | ------------------ | -------------------------- |
 | `local`   | ✔             | 🠗 `detectChanges` | ✔ ComponentContext | `requestAnimationFrame`   |
 | `global`  | ✔             | ⮁ `ɵmarkDirty`    | ✔ RootContext     | `requestAnimationFrame`   |
 | `detach`  | ✔             | ⭭ `detectChanges` | ✔ ComponentContext | `requestAnimationFrame`   |
 | `noop`    | ✔             | - `noop`          | ❌                 | ❌                        |
 | `native`  | ❌             | ⮁ `markForCheck` | ✔ RootContext     | `requestAnimationFrame`  |
