### PR TITLE
Harmonize reactive context

### DIFF
--- a/libs/template/spec/core/render-aware/render-aware_creator.spec.ts
+++ b/libs/template/spec/core/render-aware/render-aware_creator.spec.ts
@@ -30,7 +30,7 @@ class CdAwareImplementation<U> implements OnDestroy {
   resetObserver: NextObserver<any> = {
     next: _ => (this.renderedValue = undefined)
   };
-  updateObserver: Observer<U | undefined | null> = {
+  templateObserver: Observer<U | undefined | null> = {
     next: (n: U | undefined | null) => {
       this.renderedValue = n;
     },
@@ -41,7 +41,7 @@ class CdAwareImplementation<U> implements OnDestroy {
   constructor(strategySelection: StrategySelection) {
     this.cdAware = createRenderAware<U>({
       strategies: strategySelection,
-      updateObserver: this.updateObserver,
+      templateObserver: this.templateObserver,
       resetObserver: this.resetObserver
     });
     this.cdAware.nextStrategy(DEFAULT_STRATEGY_NAME);

--- a/libs/template/spec/core/render-aware/render-aware_creator.spec.ts
+++ b/libs/template/spec/core/render-aware/render-aware_creator.spec.ts
@@ -18,6 +18,7 @@ import { DEFAULT_STRATEGY_NAME } from '../../../src/lib/render-strategies/strate
 // tslint:disable-next-line:nx-enforce-module-boundaries
 import { jestMatcher, mockConsole } from '@test-helpers';
 import createSpy = jasmine.createSpy;
+import { RxTemplateObserver } from '../../../src/lib/core/model';
 
 
 // TODO: Add Angular decorator.
@@ -27,10 +28,16 @@ class CdAwareImplementation<U> implements OnDestroy {
   public completed = false;
   private readonly subscription: Unsubscribable;
   public cdAware: RenderAware<U | undefined | null>;
-  resetObserver: NextObserver<any> = {
+  resetObserver: RxTemplateObserver<U | undefined | null> = {
+    suspense: () => {
+      (this.renderedValue = undefined)
+    },
     next: _ => (this.renderedValue = undefined)
   };
-  templateObserver: Observer<U | undefined | null> = {
+  templateObserver: RxTemplateObserver<U | undefined | null> = {
+    suspense: () => {
+      (this.renderedValue = undefined)
+    },
     next: (n: U | undefined | null) => {
       this.renderedValue = n;
     },

--- a/libs/template/spec/core/render-aware/render-aware_creator.spec.ts
+++ b/libs/template/spec/core/render-aware/render-aware_creator.spec.ts
@@ -28,12 +28,7 @@ class CdAwareImplementation<U> implements OnDestroy {
   public completed = false;
   private readonly subscription: Unsubscribable;
   public cdAware: RenderAware<U | undefined | null>;
-  resetObserver: RxTemplateObserver<U | undefined | null> = {
-    suspense: () => {
-      (this.renderedValue = undefined)
-    },
-    next: _ => (this.renderedValue = undefined)
-  };
+
   templateObserver: RxTemplateObserver<U | undefined | null> = {
     suspense: () => {
       (this.renderedValue = undefined)
@@ -48,8 +43,7 @@ class CdAwareImplementation<U> implements OnDestroy {
   constructor(strategySelection: StrategySelection) {
     this.cdAware = createRenderAware<U>({
       strategies: strategySelection,
-      templateObserver: this.templateObserver,
-      resetObserver: this.resetObserver
+      templateObserver: this.templateObserver
     });
     this.cdAware.nextStrategy(DEFAULT_STRATEGY_NAME);
     this.subscription = this.cdAware.subscribe();

--- a/libs/template/src/lib/core/model.ts
+++ b/libs/template/src/lib/core/model.ts
@@ -1,0 +1,21 @@
+import { NextObserver } from 'rxjs';
+
+export interface RxViewContext<T> {
+  // to enable `let` syntax we have to use $implicit (var; let v = var)
+  $implicit: T;
+  // set context var complete to true (var$; let e = $error)
+  $error: boolean;
+  // set context var complete to true (var$; let c = $complete)
+  $complete: boolean;
+  // set context var suspense to true (var$; let c = $suspense)
+  $suspense: boolean;
+}
+
+/**
+ * @description
+ *
+ * Callbacks for the templates main states: suspense, next, error, complete
+ */
+export interface RxTemplateObserver<T> extends NextObserver<T> {
+  suspense?: () => void;
+}

--- a/libs/template/src/lib/core/render-aware/render-aware_creator.ts
+++ b/libs/template/src/lib/core/render-aware/render-aware_creator.ts
@@ -1,6 +1,5 @@
 import {
   MonoTypeOperatorFunction,
-  NextObserver,
   Observable,
   of,
   ReplaySubject,
@@ -37,7 +36,6 @@ export interface RenderAware<U> extends Subscribable<U> {
  */
 export function createRenderAware<U>(cfg: {
   strategies: StrategySelection;
-  resetObserver: RxTemplateObserver<U>;
   templateObserver: RxTemplateObserver<U>;
 }): RenderAware<U | undefined | null> {
   const strategyName$ = new ReplaySubject<string | Observable<string>>(1);
@@ -75,7 +73,7 @@ export function createRenderAware<U>(cfg: {
         return of(null);
       }
       if (!firstTemplateObservableChange) {
-        cfg.resetObserver.suspense();
+        cfg.templateObserver.suspense();
         if (observable$ === undefined) {
           return of(undefined);
         }

--- a/libs/template/src/lib/core/render-aware/render-aware_creator.ts
+++ b/libs/template/src/lib/core/render-aware/render-aware_creator.ts
@@ -18,6 +18,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 import { RenderStrategy, StrategySelection } from './interfaces';
+import { RxTemplateObserver } from '../model';
 
 export interface RenderAware<U> extends Subscribable<U> {
   nextPotentialObservable: (value: any) => void;
@@ -37,7 +38,7 @@ export interface RenderAware<U> extends Subscribable<U> {
 export function createRenderAware<U>(cfg: {
   strategies: StrategySelection;
   resetObserver: NextObserver<void>;
-  updateObserver: NextObserver<U>;
+  templateObserver: RxTemplateObserver<U>;
 }): RenderAware<U | undefined | null> {
   const strategyName$ = new ReplaySubject<string | Observable<string>>(1);
   let currentStrategy: RenderStrategy;
@@ -92,7 +93,7 @@ export function createRenderAware<U>(cfg: {
           // Forward only distinct values
           distinctUntilChanged(),
           // Update completion, error and next
-          tap(cfg.updateObserver),
+          tap(cfg.templateObserver),
           renderWithLatestStrategy(strategy$)
         )
     )

--- a/libs/template/src/lib/core/render-aware/render-aware_creator.ts
+++ b/libs/template/src/lib/core/render-aware/render-aware_creator.ts
@@ -37,7 +37,7 @@ export interface RenderAware<U> extends Subscribable<U> {
  */
 export function createRenderAware<U>(cfg: {
   strategies: StrategySelection;
-  resetObserver: NextObserver<void>;
+  resetObserver: RxTemplateObserver<U>;
   templateObserver: RxTemplateObserver<U>;
 }): RenderAware<U | undefined | null> {
   const strategyName$ = new ReplaySubject<string | Observable<string>>(1);
@@ -75,7 +75,7 @@ export function createRenderAware<U>(cfg: {
         return of(null);
       }
       if (!firstTemplateObservableChange) {
-        cfg.resetObserver.next();
+        cfg.resetObserver.suspense();
         if (observable$ === undefined) {
           return of(undefined);
         }

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -9,10 +9,8 @@ import {
 } from '@angular/core';
 
 import {
-  NextObserver,
   Observable,
   ObservableInput,
-  Observer,
   Subscription,
   Unsubscribable,
 } from 'rxjs';
@@ -25,7 +23,7 @@ import {
   DEFAULT_STRATEGY_NAME,
   getStrategies,
 } from '../render-strategies/strategies/strategies-map';
-import { RxTemplateObserver } from '../core/model';
+import { RxTemplateObserver, RxViewContext } from '../core/model';
 
 type RxTemplateName = 'rxNext' | 'rxComplete' | 'rxError' | 'rxSuspense';
 
@@ -308,18 +306,6 @@ export class LetDirective<U> implements OnInit, OnDestroy {
     LetViewContext<U | undefined | null>,
     RxTemplateName
   >;
-  private readonly resetObserver: RxTemplateObserver<U | null | undefined> = {
-    suspense: () => {
-      this.displayInitialView();
-      this.templateManager.updateViewContext({
-        $implicit: undefined,
-        rxLet: undefined,
-        $error: false,
-        $complete: false,
-      });
-    },
-    next() {}
-  };
   private readonly templateObserver: RxTemplateObserver<U | null | undefined> = {
     suspense: () => {
       this.displayInitialView();
@@ -385,7 +371,6 @@ export class LetDirective<U> implements OnInit, OnDestroy {
 
     this.renderAware = createRenderAware({
       strategies: this.strategies,
-      resetObserver: this.resetObserver,
       templateObserver: this.templateObserver,
     });
     this.renderAware.nextStrategy(DEFAULT_STRATEGY_NAME);

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -308,8 +308,8 @@ export class LetDirective<U> implements OnInit, OnDestroy {
     LetViewContext<U | undefined | null>,
     RxTemplateName
   >;
-  private readonly resetObserver: NextObserver<void> = {
-    next: () => {
+  private readonly resetObserver: RxTemplateObserver<U | null | undefined> = {
+    suspense: () => {
       this.displayInitialView();
       this.templateManager.updateViewContext({
         $implicit: undefined,
@@ -318,6 +318,7 @@ export class LetDirective<U> implements OnInit, OnDestroy {
         $complete: false,
       });
     },
+    next() {}
   };
   private readonly templateObserver: RxTemplateObserver<U | null | undefined> = {
     suspense: () => {

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_STRATEGY_NAME,
   getStrategies,
 } from '../render-strategies/strategies/strategies-map';
+import { RxTemplateObserver } from '../core/model';
 
 type RxTemplateName = 'rxNext' | 'rxComplete' | 'rxError' | 'rxSuspense';
 
@@ -318,7 +319,16 @@ export class LetDirective<U> implements OnInit, OnDestroy {
       });
     },
   };
-  private readonly updateObserver: Observer<U | null | undefined> = {
+  private readonly templateObserver: RxTemplateObserver<U | null | undefined> = {
+    suspense: () => {
+      this.displayInitialView();
+      this.templateManager.updateViewContext({
+        $implicit: undefined,
+        rxLet: undefined,
+        $error: false,
+        $complete: false,
+      });
+    },
     next: (value: U | null | undefined) => {
       this.templateManager.displayView('rxNext');
       this.templateManager.updateViewContext({
@@ -375,7 +385,7 @@ export class LetDirective<U> implements OnInit, OnDestroy {
     this.renderAware = createRenderAware({
       strategies: this.strategies,
       resetObserver: this.resetObserver,
-      updateObserver: this.updateObserver,
+      templateObserver: this.templateObserver,
     });
     this.renderAware.nextStrategy(DEFAULT_STRATEGY_NAME);
   }

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -27,15 +27,9 @@ import { RxTemplateObserver, RxViewContext } from '../core/model';
 
 type RxTemplateName = 'rxNext' | 'rxComplete' | 'rxError' | 'rxSuspense';
 
-export interface LetViewContext<T> {
-  // to enable `let` syntax we have to use $implicit (var; let v = var)
-  $implicit: T;
+export interface LetViewContext<T> extends RxViewContext<T>  {
   // to enable `as` syntax we have to assign the directives selector (var as v)
   rxLet: T;
-  // set context var complete to true (var$; let e = $error)
-  $error: boolean;
-  // set context var complete to true (var$; let c = $complete)
-  $complete: boolean;
 }
 
 /**
@@ -162,6 +156,14 @@ export class LetDirective<U> implements OnInit, OnDestroy {
    * @internal
    */
   static ngTemplateGuard_rxLet: 'binding';
+
+  readonly initialViewContext: LetViewContext<U> = {
+    $implicit: undefined,
+    rxLet: undefined,
+    $error: false,
+    $complete: false,
+    $suspense: false
+  };
 
   /**
    * @description
@@ -362,12 +364,7 @@ export class LetDirective<U> implements OnInit, OnDestroy {
     private readonly viewContainerRef: ViewContainerRef
   ) {
     this.strategies = getStrategies({ cdRef });
-    this.templateManager = createTemplateManager(this.viewContainerRef, {
-      $implicit: undefined,
-      rxLet: undefined,
-      $error: false,
-      $complete: false,
-    });
+    this.templateManager = createTemplateManager(this.viewContainerRef, this.initialViewContext);
 
     this.renderAware = createRenderAware({
       strategies: this.strategies,

--- a/libs/template/src/lib/push/push.pipe.ts
+++ b/libs/template/src/lib/push/push.pipe.ts
@@ -64,10 +64,11 @@ export class PushPipe<U> implements PipeTransform, OnDestroy {
 
   private readonly subscription: Unsubscribable;
   private readonly RenderAware: RenderAware<U | null | undefined>;
-  private readonly resetObserver: NextObserver<void> = {
-    next: () => {
+  private readonly resetObserver: RxTemplateObserver<U  | null | undefined> = {
+    suspense: () => {
       this.renderedValue = undefined;
     },
+    next: (value: U | null | undefined) =>  this.renderedValue = undefined,
   };
   private readonly templateObserver: RxTemplateObserver<U | null | undefined> = {
     suspense: () => this.renderedValue = undefined,

--- a/libs/template/src/lib/push/push.pipe.ts
+++ b/libs/template/src/lib/push/push.pipe.ts
@@ -5,7 +5,6 @@ import {
   PipeTransform,
 } from '@angular/core';
 import {
-  NextObserver,
   Observable,
   ObservableInput,
   Unsubscribable,
@@ -64,12 +63,7 @@ export class PushPipe<U> implements PipeTransform, OnDestroy {
 
   private readonly subscription: Unsubscribable;
   private readonly RenderAware: RenderAware<U | null | undefined>;
-  private readonly resetObserver: RxTemplateObserver<U  | null | undefined> = {
-    suspense: () => {
-      this.renderedValue = undefined;
-    },
-    next: (value: U | null | undefined) =>  this.renderedValue = undefined,
-  };
+
   private readonly templateObserver: RxTemplateObserver<U | null | undefined> = {
     suspense: () => this.renderedValue = undefined,
     next: (value: U | null | undefined) => this.renderedValue = value,
@@ -80,8 +74,7 @@ export class PushPipe<U> implements PipeTransform, OnDestroy {
       strategies: getStrategies({
         cdRef,
       }),
-      templateObserver: this.templateObserver,
-      resetObserver: this.resetObserver,
+      templateObserver: this.templateObserver
     });
     this.subscription = this.RenderAware.subscribe();
   }

--- a/libs/template/src/lib/push/push.pipe.ts
+++ b/libs/template/src/lib/push/push.pipe.ts
@@ -13,6 +13,7 @@ import {
 import { createRenderAware, RenderAware } from '../core';
 import { getStrategies } from '../render-strategies';
 import { DEFAULT_STRATEGY_NAME } from '../render-strategies/strategies/strategies-map';
+import { RxTemplateObserver } from '../core/model';
 
 /**
  * @Pipe PushPipe
@@ -68,8 +69,9 @@ export class PushPipe<U> implements PipeTransform, OnDestroy {
       this.renderedValue = undefined;
     },
   };
-  private readonly updateObserver: NextObserver<U | null | undefined> = {
-    next: (value: U | null | undefined) => (this.renderedValue = value),
+  private readonly templateObserver: RxTemplateObserver<U | null | undefined> = {
+    suspense: () => this.renderedValue = undefined,
+    next: (value: U | null | undefined) => this.renderedValue = value,
   };
 
   constructor(cdRef: ChangeDetectorRef) {
@@ -77,7 +79,7 @@ export class PushPipe<U> implements PipeTransform, OnDestroy {
       strategies: getStrategies({
         cdRef,
       }),
-      updateObserver: this.updateObserver,
+      templateObserver: this.templateObserver,
       resetObserver: this.resetObserver,
     });
     this.subscription = this.RenderAware.subscribe();


### PR DESCRIPTION
This PR normalized the 4 states for all templates.

It introduces:

the 4 states suspense, next, error and complete
RxTemplateObserver holds the Observer callbacks plus the suspense callback
RxViewContext which holds the default properties for a ViewContext