### PR TITLE
fix(selectSlice): fixed undefined selected key behavior

### DIFF
--- a/libs/state/src/lib/rxjs/operators/selectSlice.ts
+++ b/libs/state/src/lib/rxjs/operators/selectSlice.ts
@@ -84,21 +84,26 @@ export function selectSlice<T extends object, K extends keyof T>(
         if (state === null) {
           return null;
         }
-
+        // an array of all keys which exist and are _defined_ in the state object
         const definedKeys = keys
           // filter out undefined properties e. g. {}, { str: undefined }
           .filter((k) => state.hasOwnProperty(k) && state[k] !== undefined);
 
-        // this will get filtered out in the next operator
+        // we want to ensure to only emit _valid_ selections
+        // a selection is _valid_ if every selected key exists and has a value:
+
+        // {} => selectSlice(['foo']) => no emission
         // {str: 'test'} => selectSlice([]) => no emission
         // {str: 'test'} => selectSlice(['notPresent']) => no emission
         // {str: 'test'} => state.select(selectSlice([])) => no emission
         // {str: 'test'} => state.select(selectSlice(['notPresent'])) => no emission
+        // {str: undefined} => state.select(selectSlice(['str'])) => no emission
+        // {str: 'test', foo: undefined } => state.select(selectSlice(['foo'])) => no emission
         if (definedKeys.length < keys.length) {
           return undefined;
         }
 
-        // create view-model
+        // create the selected slice
         return definedKeys
           .reduce((vm, key) => {
             vm[key] = state[key];

--- a/libs/state/src/lib/rxjs/operators/selectSlice.ts
+++ b/libs/state/src/lib/rxjs/operators/selectSlice.ts
@@ -10,6 +10,10 @@ import { distinctUntilSomeChanged } from './distinctUntilSomeChanged';
  * filtered to only emit _defined_ values as well as checked for distinct emissions.
  * Comparison will be done for each set key in the `keys` array.
  *
+ * `selectSlice` will only emit _valid_ selections. A selection is _valid_ if every
+ * selected key exists and is defined in the source Observable. This ensures that the `selectSlice`
+ * operator will always return a complete slice with all values defined.
+ *
  * You can fine grain your distinct checks by providing a `KeyCompareMap` with those keys you want to compute
  * explicitly different
  *

--- a/libs/state/src/lib/rxjs/operators/selectSlice.ts
+++ b/libs/state/src/lib/rxjs/operators/selectSlice.ts
@@ -94,13 +94,12 @@ export function selectSlice<T extends object, K extends keyof T>(
         // {str: 'test'} => selectSlice(['notPresent']) => no emission
         // {str: 'test'} => state.select(selectSlice([])) => no emission
         // {str: 'test'} => state.select(selectSlice(['notPresent'])) => no emission
-        if (definedKeys.length <= 0) {
+        if (definedKeys.length < keys.length) {
           return undefined;
         }
 
         // create view-model
         return definedKeys
-          .filter((k) => state.hasOwnProperty(k) && state[k] !== undefined)
           .reduce((vm, key) => {
             vm[key] = state[key];
             return vm;


### PR DESCRIPTION
### Description
As reported in this issue: #281 the `selectSlice` operator emits slices where values potentially can be undefined. From my personal experience I can tell that this behavior often leads to the usage of `filter` to check if all selected keys are really defined.

### Solution
I have implemented a simple check if the length of the `definedKeys` is less than the length of the provided `keys` array.

```ts
const definedKeys = keys
        // filter out undefined properties e. g. {}, { str: undefined }
        .filter((k) => state.hasOwnProperty(k) && state[k] !== undefined);
if (definedKeys.length < keys.length) {
  return undefined;
}
```

### Status

* implemented new undefined check
* added tests for the new behavior