### PR TITLE
Poc rxfor

### DIFF
--- a/apps/experiments/src/app/app.menu.ts
+++ b/apps/experiments/src/app/app.menu.ts
@@ -6,6 +6,7 @@ import { MENU_ITEMS as LET_MENU_ITEMS } from './let/let.menu';
 import { MENU_ITEMS as MIXED_MENU_ITEMS } from './mixed/mixed.menu';
 import { MENU_ITEMS as CD_OPERATORS_MENU_ITEMS } from './cd-operators/cd-operators.menu';
 import { MENU_ITEMS as RX_STATE_MENU_ITEMS } from './state/rx-state.menu';
+import { MENU_ITEMS as RX_FOR_MENU_ITEMS } from './for/for-poc.menu';
 import { STRATEGIES_MENU } from './strategies/strategies.menu';
 
 export const MENU_ITEMS: MenuItem[] = [
@@ -17,4 +18,5 @@ export const MENU_ITEMS: MenuItem[] = [
   ...CD_OPERATORS_MENU_ITEMS,
   ...RX_STATE_MENU_ITEMS,
   ...STRATEGIES_MENU,
+  ...RX_FOR_MENU_ITEMS
 ];

--- a/apps/experiments/src/app/app.routing.ts
+++ b/apps/experiments/src/app/app.routing.ts
@@ -61,4 +61,9 @@ export const ROUTES: Routes = [
     loadChildren: () =>
       import('./strategies/strategies.module').then((m) => m.StrategiesModule),
   },
+  {
+    path: 'for-poc',
+    loadChildren: () =>
+      import('./for/for-poc.module').then((m) => m.ForPocModule),
+  },
 ];

--- a/apps/experiments/src/app/for/advanced/for.directive.ts
+++ b/apps/experiments/src/app/for/advanced/for.directive.ts
@@ -1,0 +1,176 @@
+import {
+  ChangeDetectorRef,
+  Directive,
+  EmbeddedViewRef,
+  Input,
+  IterableChangeRecord,
+  IterableChanges,
+  IterableDiffer,
+  IterableDiffers,
+  NgIterable,
+  OnDestroy,
+  OnInit,
+  TemplateRef, TrackByFunction,
+  ViewContainerRef
+} from '@angular/core';
+
+import { ObservableInput, ReplaySubject, Subscription, Unsubscribable } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchAll, tap } from 'rxjs/operators';
+
+export class PocForViewContext<T, U extends NgIterable<T> = NgIterable<T>> {
+
+  constructor(public $implicit: T, public pocLet: U, public index: number, public count: number) {}
+
+  get first(): boolean {
+    return this.index === 0;
+  }
+
+  get last(): boolean {
+    return this.index === this.count - 1;
+  }
+
+  get even(): boolean {
+    return this.index % 2 === 0;
+  }
+
+  get odd(): boolean {
+    return !this.even;
+  }
+}
+interface RecordViewTuple<T, U extends NgIterable<T>> {
+  record: any;
+  view: EmbeddedViewRef<PocForViewContext<T, U>>;
+}
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: '[pocForAdvanced]'
+})
+export class ForPocAdvancedDirective<T, U extends NgIterable<T> = NgIterable<T>> implements OnInit, OnDestroy {
+  observables$ = new ReplaySubject<ObservableInput<U & NgIterable<T>>>(1);
+  values: U & NgIterable<T>;
+  changes$ = this.observables$
+    .pipe(
+      distinctUntilChanged(),
+      switchAll(),
+      // the actual values arrive here
+      tap(value => {
+        // set helper variable for applyChanges method
+        this.values = value;
+        // set new differ if there is none yet
+        if (!this.differ && value) {
+          this.differ = this.iterableDiffers.find(value).create(this._trackByFn);
+        }
+      }),
+      // if there is no differ, we don't need to apply changes
+      filter(() => !!this.differ),
+      // apply differ -> return changes
+      map(value => this.differ.diff(value)),
+      // filter out no changes
+      filter(changes => !!changes)
+    );
+
+  private _trackByFn: TrackByFunction<T>;
+  @Input()
+  set pocForAdvancedTrackBy(fn: TrackByFunction<T>) {
+    this._trackByFn = fn;
+  }
+
+  @Input()
+  set pocForAdvanced(potentialObservable: ObservableInput<U & NgIterable<T>> | null | undefined) {
+    this.observables$.next(potentialObservable);
+  }
+
+  private differ: IterableDiffer<T> | null = null;
+
+  private subscription: Unsubscribable = new Subscription();
+
+  constructor(
+    private cdRef: ChangeDetectorRef,
+    private readonly nextTemplateRef: TemplateRef<PocForViewContext<T, U>>,
+    private readonly viewContainerRef: ViewContainerRef,
+    private iterableDiffers: IterableDiffers
+  ) {
+
+  }
+
+  ngOnInit() {
+    this.subscription = this.changes$
+      .subscribe(
+        changes => {
+          this.applyChanges(changes);
+        }
+      );
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  private applyChanges(changes: IterableChanges<T>) {
+    // behavior like *ngFor
+    const insertTuples: RecordViewTuple<T, U>[] = [];
+    // TODO: dig into `IterableDiffer`
+    changes.forEachOperation(
+      (
+        changeRecord: IterableChangeRecord<T>,
+        previousIndex: number | null,
+        currentIndex: number | null
+      ) => {
+        if (changeRecord.previousIndex == null) {
+          // this is basically the first run
+          // create the embedded view for each value with default values
+          const view = this.viewContainerRef.createEmbeddedView(
+            this.nextTemplateRef,
+            new PocForViewContext<T, U>(null, this.values, -1, -1),
+            currentIndex === null ? undefined : currentIndex
+          );
+          insertTuples.push({
+            view,
+            record: changeRecord
+          });
+
+        } else if (currentIndex == null) {
+
+          this.viewContainerRef.remove(
+            previousIndex === null ? undefined : previousIndex);
+
+        } else if (previousIndex !== null) {
+
+          const view = <EmbeddedViewRef<PocForViewContext<T, U>>>this.viewContainerRef.get(previousIndex);
+          this.viewContainerRef.move(view, currentIndex);
+          insertTuples.push({
+            view,
+            record: changeRecord
+          });
+        }
+      });
+
+    for (let i = 0; i < insertTuples.length; i++) {
+      this._perViewChange(insertTuples[i].view, insertTuples[i].record);
+    }
+
+    for (let i = 0, ilen = this.viewContainerRef.length; i < ilen; i++) {
+      const viewRef = <EmbeddedViewRef<PocForViewContext<T, U>>>this.viewContainerRef.get(i);
+      viewRef.context.index = i;
+      viewRef.context.count = ilen;
+      viewRef.context.pocLet = this.values;
+    }
+
+    changes.forEachIdentityChange((record: IterableChangeRecord<T>) => {
+      const viewRef =
+        <EmbeddedViewRef<PocForViewContext<T, U>>>this.viewContainerRef.get(record.currentIndex);
+      viewRef.context.$implicit = record.item;
+      viewRef.detectChanges();
+    });
+  }
+
+  private _perViewChange(
+    view: EmbeddedViewRef<PocForViewContext<T, U>>, record: IterableChangeRecord<T>) {
+    view.context.$implicit = record.item;
+    view.detectChanges();
+  }
+
+}
+
+

--- a/apps/experiments/src/app/for/advanced/parent.component.ts
+++ b/apps/experiments/src/app/for/advanced/parent.component.ts
@@ -1,0 +1,61 @@
+import { Component } from '@angular/core';
+import { update } from '@rx-angular/state';
+import { merge, Subject } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+import { Hero, heroes } from '../data';
+
+@Component({
+  selector: 'app-for-poc-advanced-parent',
+  template: `
+    <h2>
+      RxFor Advanced Implementation
+    </h2>
+
+    <button [unpatch] (click)="toggleClick$.next($event)">
+      refresh data
+    </button>
+
+    <!--<renders></renders>-->
+
+    <div class="item-list">
+      <div class="item" *pocForAdvanced="items$; let item; trackBy: trackHero">
+        <!--<renders></renders>-->
+        {{ item.name }}
+        <button [unpatch] (click)="toggleUpdate$.next(item)">
+          update me
+        </button>
+      </div>
+    </div>
+  `,
+  styles: [
+      `
+      .item-list {
+        display: flex;
+        flex-flow: column;
+      }
+
+      .item {
+        padding: 1rem;
+        outline: 1px solid darkmagenta;
+      }
+    `
+  ],
+  changeDetection: environment.changeDetection,
+})
+export class ForPocAdvancedParentComponent {
+  toggleClick$ = new Subject<Event>();
+  toggleUpdate$ = new Subject<Hero>();
+  items$ = merge(
+    this.toggleClick$.pipe(
+      map(() => [...heroes]),
+    ),
+    this.toggleUpdate$.pipe(
+      map(({ id, name }) => update(heroes, { id, name: `n_${ name }` }, 'id')),
+    )
+  );
+
+  trackHero(index: number, hero: Hero): number {
+    return hero.id;
+  }
+}

--- a/apps/experiments/src/app/for/advanced/parent.component.ts
+++ b/apps/experiments/src/app/for/advanced/parent.component.ts
@@ -16,11 +16,11 @@ import { Hero, heroes } from '../data';
       refresh data
     </button>
 
-    <!--<renders></renders>-->
+    <renders></renders>
 
     <div class="item-list">
       <div class="item" *pocForAdvanced="items$; let item; trackBy: trackHero">
-        <!--<renders></renders>-->
+        <renders></renders>
         {{ item.name }}
         <button [unpatch] (click)="toggleUpdate$.next(item)">
           update me

--- a/apps/experiments/src/app/for/basic/for.directive.ts
+++ b/apps/experiments/src/app/for/basic/for.directive.ts
@@ -1,0 +1,102 @@
+import {
+  ChangeDetectorRef,
+  Directive,
+  EmbeddedViewRef,
+  Input,
+  NgIterable,
+  OnDestroy,
+  OnInit,
+  TemplateRef,
+  ViewContainerRef
+} from '@angular/core';
+
+import { ObservableInput, ReplaySubject, Subscription, Unsubscribable } from 'rxjs';
+import { distinctUntilChanged, switchAll } from 'rxjs/operators';
+
+export interface PocForViewContext<T, U extends NgIterable<T> = NgIterable<T>> {
+  $implicit: T;
+  pocLet: U;
+  index: number;
+  count: number;
+}
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: '[pocForBasic]'
+})
+export class ForPocBasicDirective<T, U extends NgIterable<T> = NgIterable<T>> implements OnInit, OnDestroy {
+  observables$ = new ReplaySubject<ObservableInput<U & NgIterable<T>>>(1);
+  viewContext = { $implicit: undefined };
+  embeddedView;
+  values: U & NgIterable<T>;
+  values$ = this.observables$
+    .pipe(
+      distinctUntilChanged(),
+      switchAll(),
+      distinctUntilChanged()
+    );
+
+  @Input()
+  set pocForBasic(potentialObservable: ObservableInput<U & NgIterable<T>> | null | undefined) {
+    this.observables$.next(potentialObservable);
+  }
+  private subscription: Unsubscribable = new Subscription();
+
+  constructor(
+    private cdRef: ChangeDetectorRef,
+    private readonly nextTemplateRef: TemplateRef<PocForViewContext<T, U>>,
+    private readonly viewContainerRef: ViewContainerRef
+  ) {
+
+  }
+
+  ngOnInit() {
+    this.subscription = this.values$
+      .subscribe(
+        values => {
+          this.renderValues(values);
+        }
+      );
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  private renderValues(values: U & NgIterable<T> | null | undefined) {
+    // this is the most easy way that I could think of implementing a very basic rxFor directive just rendering
+    // an array of templates
+    if (values) {
+      let i = 0;
+      for (const value of values) {
+        let view = this.viewContainerRef.get(i);
+        if (!!view) {
+          this.viewContainerRef.remove(i);
+        }
+        view = this.viewContainerRef.createEmbeddedView(
+          this.nextTemplateRef,
+          {
+            $implicit: null,
+            pocLet: values,
+            count: -1,
+            index: -1
+          },
+          i
+        );
+        (view as EmbeddedViewRef<PocForViewContext<T, U>>).context.$implicit = value;
+        i++;
+      }
+      for (let i = 0, ilen = this.viewContainerRef.length; i < ilen; i++) {
+        const viewRef = <EmbeddedViewRef<PocForViewContext<T, U>>>this.viewContainerRef.get(i);
+        viewRef.context.index = i;
+        viewRef.context.count = ilen;
+        viewRef.context.pocLet = this.values;
+        viewRef.detectChanges();
+      }
+    } else {
+      this.viewContainerRef.clear();
+      this.cdRef.detectChanges();
+    }
+  }
+
+}

--- a/apps/experiments/src/app/for/basic/parent.component.ts
+++ b/apps/experiments/src/app/for/basic/parent.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { Subject } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { todos } from '../data';
+
+@Component({
+  selector: 'app-for-poc-basic-parent',
+  template: `
+    <h2>
+      RxFor Basic Implementation
+    </h2>
+
+    <button [unpatch] (click)="toggleClick$.next($event)">
+      toggle
+    </button>
+
+    <!--<renders></renders>-->
+
+    <div class="row">
+      <div class="col">
+        <ng-container *pocForBasic="items$; let item">
+          <!--<renders></renders>-->
+          {{ item }}
+        </ng-container>
+      </div>
+
+    </div>
+  `,
+  changeDetection: environment.changeDetection,
+})
+export class ForPocBasicParentComponent {
+  toggleClick$ = new Subject<Event>();
+  items$ = this.toggleClick$.pipe(
+    map(() => [...todos])
+  );
+}

--- a/apps/experiments/src/app/for/basic/parent.component.ts
+++ b/apps/experiments/src/app/for/basic/parent.component.ts
@@ -15,12 +15,12 @@ import { todos } from '../data';
       toggle
     </button>
 
-    <!--<renders></renders>-->
+    <renders></renders>
 
     <div class="row">
       <div class="col">
         <ng-container *pocForBasic="items$; let item">
-          <!--<renders></renders>-->
+          <renders></renders>
           {{ item }}
         </ng-container>
       </div>

--- a/apps/experiments/src/app/for/data.ts
+++ b/apps/experiments/src/app/for/data.ts
@@ -1,0 +1,25 @@
+export interface Hero {
+  id: number;
+  name: string;
+}
+
+export const heroes: Hero[] = [
+  { id: 11, name: 'Dr Nice' },
+  { id: 12, name: 'Narco' },
+  { id: 13, name: 'Bombasto' },
+  { id: 14, name: 'Celeritas' },
+  { id: 15, name: 'Magneta' },
+  { id: 16, name: 'RubberMan' },
+  { id: 17, name: 'Dynama' },
+  { id: 18, name: 'Dr IQ' },
+  { id: 19, name: 'Magma' },
+  { id: 20, name: 'Tornado' }
+];
+
+export const todos = [
+  'feed cat',
+  'wash kitchen',
+  'read article xy',
+  'fix #3438ajc',
+  'implement *rxFor'
+];

--- a/apps/experiments/src/app/for/for-poc-overview.component.ts
+++ b/apps/experiments/src/app/for/for-poc-overview.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { environment } from '../../environments/environment';
+
+@Component({
+  selector: 'app-for-poc-overview',
+  template: `
+    <h1>CD EmbeddedView Overview</h1>
+    <div class="cases-overview">
+      <app-for-poc-basic-parent class="item">
+      </app-for-poc-basic-parent>
+      <app-for-poc-advanced-parent class="item">
+      </app-for-poc-advanced-parent>
+    </div>
+  `,
+  changeDetection: environment.changeDetection,
+})
+export class ForPocOverviewComponent {}

--- a/apps/experiments/src/app/for/for-poc.menu.ts
+++ b/apps/experiments/src/app/for/for-poc.menu.ts
@@ -1,0 +1,19 @@
+import { MenuItem } from '../core/navigation/menu-item.interface';
+
+export const MENU_ITEMS: MenuItem[] = [
+  {
+    link: 'for-poc',
+    label: 'RxFor Poc',
+    children: [
+      // 01.
+      {
+        link: 'for-poc/basic',
+        label: 'RxFor Basic PoC',
+      },
+      {
+        link: 'for-poc/advanced',
+        label: 'RxFor Advanced PoC',
+      }
+    ],
+  },
+];

--- a/apps/experiments/src/app/for/for-poc.module.ts
+++ b/apps/experiments/src/app/for/for-poc.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { UnpatchEventsModule } from '@rx-angular/template';
 import { RouterModule } from '@angular/router';
+import { RendersModule } from '../renders/renders.module';
 import { ForPocBasicParentComponent } from './basic/parent.component';
 import { ForPocBasicDirective } from './basic/for.directive';
 import { ForPocAdvancedParentComponent } from './advanced/parent.component';
@@ -9,7 +10,6 @@ import { ForPocAdvancedDirective } from './advanced/for.directive';
 import { ROUTES as CD_ROUTES } from './for-poc.routes';
 
 import { ForPocOverviewComponent } from './for-poc-overview.component';
-//import { RendersModule } from '../renders/renders.module';
 
 @NgModule({
   declarations: [
@@ -23,7 +23,7 @@ import { ForPocOverviewComponent } from './for-poc-overview.component';
     CommonModule,
     RouterModule.forChild(CD_ROUTES),
     UnpatchEventsModule,
-    //RendersModule
+    RendersModule
   ]
 })
 export class ForPocModule {

--- a/apps/experiments/src/app/for/for-poc.module.ts
+++ b/apps/experiments/src/app/for/for-poc.module.ts
@@ -1,0 +1,30 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { UnpatchEventsModule } from '@rx-angular/template';
+import { RouterModule } from '@angular/router';
+import { ForPocBasicParentComponent } from './basic/parent.component';
+import { ForPocBasicDirective } from './basic/for.directive';
+import { ForPocAdvancedParentComponent } from './advanced/parent.component';
+import { ForPocAdvancedDirective } from './advanced/for.directive';
+import { ROUTES as CD_ROUTES } from './for-poc.routes';
+
+import { ForPocOverviewComponent } from './for-poc-overview.component';
+//import { RendersModule } from '../renders/renders.module';
+
+@NgModule({
+  declarations: [
+    ForPocBasicDirective,
+    ForPocAdvancedDirective,
+    ForPocBasicParentComponent,
+    ForPocAdvancedParentComponent,
+    ForPocOverviewComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(CD_ROUTES),
+    UnpatchEventsModule,
+    //RendersModule
+  ]
+})
+export class ForPocModule {
+}

--- a/apps/experiments/src/app/for/for-poc.routes.ts
+++ b/apps/experiments/src/app/for/for-poc.routes.ts
@@ -1,0 +1,23 @@
+
+import { ForPocBasicParentComponent } from './basic/parent.component';
+import { ForPocAdvancedParentComponent } from './advanced/parent.component';
+import { ForPocOverviewComponent } from './for-poc-overview.component';
+
+export const ROUTES = [
+  {
+    path: '',
+    redirectTo: 'overview'
+  },
+  {
+    path: 'overview',
+    component: ForPocOverviewComponent,
+  },
+  {
+    path: 'basic',
+    component: ForPocBasicParentComponent,
+  },
+  {
+    path: 'advanced',
+    component: ForPocAdvancedParentComponent,
+  },
+];

--- a/apps/experiments/src/app/renders/num-render.component.html
+++ b/apps/experiments/src/app/renders/num-render.component.html
@@ -1,0 +1,3 @@
+<div class="rx-num-render" matRipple [matRippleColor]="'rgba(253,255,0,0.24)'">
+  {{ render() }}
+</div>

--- a/apps/experiments/src/app/renders/num-render.component.scss
+++ b/apps/experiments/src/app/renders/num-render.component.scss
@@ -1,0 +1,19 @@
+:host {
+  mat-ripple:not(:empty) {
+    transform: translateZ(0);
+  }
+  .mat-ripple {
+    overflow: hidden;
+    position: relative;
+  }
+
+  .rx-num-render {
+    text-shadow: 1px 1px 1px gray;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/apps/experiments/src/app/renders/num-render.component.ts
+++ b/apps/experiments/src/app/renders/num-render.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { MatRipple } from '@angular/material/core';
+
+@Component({
+  // tslint:disable-next-line:component-selector
+  selector: 'renders',
+  templateUrl: './num-render.component.html',
+  styleUrls: ['./num-render.component.scss'],
+})
+export class NumRenderComponent implements OnInit {
+  @ViewChild(MatRipple) ripple: MatRipple;
+
+  renders = 0;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  render() {
+    if (this.ripple) {
+      this.ripple.launch({ centered: true });
+    }
+    return ++this.renders;
+  }
+}

--- a/apps/experiments/src/app/renders/renders.module.ts
+++ b/apps/experiments/src/app/renders/renders.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NumRenderComponent } from './num-render.component';
+import { MatRippleModule } from '@angular/material/core';
+
+
+
+@NgModule({
+  declarations: [NumRenderComponent],
+  imports: [
+    CommonModule,
+    MatRippleModule
+  ],
+  exports: [NumRenderComponent]
+})
+export class RendersModule { }

--- a/apps/experiments/src/environments/environment.ts
+++ b/apps/experiments/src/environments/environment.ts
@@ -6,7 +6,7 @@ import { ChangeDetectionStrategy } from '@angular/core';
 export const environment = {
   production: false,
   zoneLess: false,
-  changeDetection: ChangeDetectionStrategy.Default,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 };
 
 /*

--- a/apps/experiments/src/polyfills.ts
+++ b/apps/experiments/src/polyfills.ts
@@ -57,7 +57,6 @@
  */
 // import './zone-flags';
 import 'zone.js/dist/zone'; // Included with Angular CLI.
-import 'zone.js/dist/zone-patch-rxjs';
 
 /***************************************************************************************************
  * APPLICATION IMPORTS


### PR DESCRIPTION
Experimental PR for upcoming `*rxFor` Directive.

This PR covers two implementations of `rxFor` prototypes:
a very basic prototype to get an impression of what has to be done in order to render multiple templates on a per template basis.
It currently re-creates every template on each change, so there is not that much to see in the example application.

* `yarn nx s experiments`
* navigate to `for-poc/basic` route

And a more advanced prototype which uses the `IterableDiffer` in order to keep track of changes coming from the input observable. Here you can see how only affected templates get rendered when the input values change.

* `yarn nx s experiments`
* navigate to `for-poc/advanced` route

 In the example there is a button which leads to an immutable update of the source value. Try it out :)
