### PR TITLE
Update usage.md

### DIFF
--- a/libs/state/docs/usage.md
+++ b/libs/state/docs/usage.md
@@ -72,10 +72,10 @@ export class StatefulComponent {
   providers: [RxState],
 })
 export class StatefulComponent {
-  readonly title$ = this.select('title');
+  readonly title$ = this.state.select('title');
 
   @Input() set title(title: string) {
-    this.state.setState({ title });
+    this.state.set({ title });
   }
 
   constructor(private state: RxState<{ title: string }>) {}
@@ -149,7 +149,7 @@ Often it is needed to get the previous state to calculate the new one.
    providers: [RxState]
 })
 export class StatefulComponent {
-   readonly items$ = this.select('items');
+   readonly items$ = this.state.select('items');
    readonly btnClick$ = new Subject();
 
    constructor(private state: RxState<{list: {id: number}}>) {


### PR DESCRIPTION
Replaced old method `setState` with `set`, replaced `this.select()` with `this.state.select()` in places where `RxState` was provided as dependency.

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
